### PR TITLE
Add mining module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "miner"
+version = "0.1.0"
+dependencies = [
+ "coin",
+ "hex",
+ "sha2",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["proto", "p2p"]
+members = ["proto", "p2p", "miner"]
 
 [package]
 name = "coin"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "miner"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+coin = { path = ".." }
+sha2 = "0.10"
+hex = "0.4"

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -1,0 +1,59 @@
+use coin::{Block, Blockchain, TransactionExt};
+use sha2::{Digest, Sha256};
+
+fn meets_difficulty(hash: &[u8], difficulty: u32) -> bool {
+    for i in 0..difficulty {
+        if hash.get(i as usize).copied().unwrap_or(0) != 0 {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn mine_block(chain: &mut Blockchain, difficulty: u32) -> Block {
+    let mut block = chain.candidate_block();
+    block.header.difficulty = difficulty;
+    loop {
+        let hash = {
+            let mut hasher = Sha256::new();
+            hasher.update(block.header.previous_hash.as_bytes());
+            hasher.update(block.header.merkle_root.as_bytes());
+            hasher.update(block.header.timestamp.to_be_bytes());
+            hasher.update(block.header.nonce.to_be_bytes());
+            hasher.update(block.header.difficulty.to_be_bytes());
+            for tx in &block.transactions {
+                hasher.update(tx.hash());
+            }
+            hasher.finalize()
+        };
+        if meets_difficulty(&hash, difficulty) {
+            break;
+        }
+        block.header.nonce += 1;
+    }
+    chain.add_block(block.clone());
+    block
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use coin::new_transaction;
+
+    #[test]
+    fn difficulty_check() {
+        assert!(meets_difficulty(&[0, 0, 1], 2));
+        assert!(!meets_difficulty(&[0, 1], 2));
+    }
+
+    #[test]
+    fn mining_adds_block() {
+        let mut bc = Blockchain::new();
+        bc.add_transaction(new_transaction("a".into(), "b".into(), 1));
+        let len_before = bc.len();
+        let block = mine_block(&mut bc, 1);
+        assert!(bc.len() > len_before);
+        let hash = hex::decode(block.hash()).unwrap();
+        assert!(meets_difficulty(&hash, 1));
+    }
+}


### PR DESCRIPTION
## Summary
- add new `miner` crate for block mining
- generate hashes with SHA-256 and check against difficulty
- append mined block to blockchain
- provide tests for mining logic

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --timeout 60 --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68607158c41c832e9e1b45a5d6b9adb5