### PR TITLE
Add block validation and broadcasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,9 @@ version = "0.1.0"
 dependencies = [
  "coin",
  "coin-proto",
+ "hex",
  "prost",
+ "sha2",
  "tokio",
 ]
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -8,3 +8,5 @@ coin-proto = { path = "../proto" }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "time", "macros"] }
 prost = "0.12"
 coin = { path = ".." }
+sha2 = "0.10"
+hex = "0.4"


### PR DESCRIPTION
## Summary
- validate received blocks for proof of work and transaction integrity
- allow nodes to broadcast mined blocks to peers
- integrate block handling in `start` loop
- test block broadcast and sync

## Testing
- `cargo fmt`
- `cargo test --workspace`
- `cargo tarpaulin --timeout 60 --workspace`


------
https://chatgpt.com/codex/tasks/task_e_686078b40e4c832ea865cfc9563bb4a3