### PR TITLE
Implement block-based sync and broadcast

### DIFF
--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -20,7 +20,7 @@ message Peers {
 message GetChain {}
 
 message Chain {
-  repeated Transaction blocks = 1;
+  repeated Block blocks = 1;
 }
 
 message BlockHeader {


### PR DESCRIPTION
## Summary
- switch Chain proto message to store blocks
- validate incoming Block messages and sync using blocks
- add internal helper for broadcasting blocks
- broadcast mined blocks via helper
- update tests for new Block handling

## Testing
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_6860a27e5b8c832ea6c28258ae7beb75