### PR TITLE
Add transaction signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,8 @@ dependencies = [
  "coin-proto",
  "hex",
  "prost",
+ "ripemd",
+ "secp256k1",
  "sha2",
  "tempfile",
 ]
@@ -202,7 +204,9 @@ dependencies = [
  "clap",
  "coin",
  "coin-proto",
+ "coin-wallet",
  "hex",
+ "hex-literal",
  "miner",
  "prost",
  "sha2",
@@ -430,7 +434,9 @@ name = "miner"
 version = "0.1.0"
 dependencies = [
  "coin",
+ "coin-wallet",
  "hex",
+ "hex-literal",
  "sha2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ hex = "0.4"
 coin-proto = { path = "proto" }
 bs58 = "0.5"
 prost = "0.12"
+secp256k1 = { version = "0.27", features = ["recovery"] }
+ripemd = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2024"
 coin = { path = ".." }
 sha2 = "0.10"
 hex = "0.4"
+
+[dev-dependencies]
+coin-wallet = { path = "../wallet" }
+hex-literal = "0.4"

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -48,9 +48,18 @@ pub fn mine_block(chain: &mut Blockchain, miner: &str) -> Block {
 mod tests {
     use super::*;
     use coin::new_transaction;
+    use coin_wallet::Wallet;
+    use hex_literal::hex;
 
     const A1: &str = "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr";
     const A2: &str = "1B1TKfsCkW5LQ6R1kSXUx7hLt49m1kwz75";
+    const SEED: [u8; 16] = hex!("000102030405060708090a0b0c0d0e0f");
+
+    fn sign_a1(tx: &mut coin::Transaction) {
+        let wallet = Wallet::from_seed(&SEED).unwrap();
+        let sk = wallet.derive_priv("m/0'/0/0").unwrap().secret_key().clone();
+        tx.sign(&sk);
+    }
 
     #[test]
     fn difficulty_check() {
@@ -61,7 +70,9 @@ mod tests {
     #[test]
     fn mining_adds_block() {
         let mut bc = Blockchain::new();
-        assert!(bc.add_transaction(new_transaction(A1, A2, 1)));
+        let mut tx = new_transaction(A1, A2, 1);
+        sign_a1(&mut tx);
+        assert!(bc.add_transaction(tx));
         let len_before = bc.len();
         let difficulty = bc.difficulty();
         let block = mine_block(&mut bc, A1);

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -13,3 +13,7 @@ hex = "0.4"
 miner = { path = "../miner" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+
+[dev-dependencies]
+coin-wallet = { path = "../wallet" }
+hex-literal = "0.4"

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -5,6 +5,7 @@ message Transaction {
   string sender = 1;
   string recipient = 2;
   uint64 amount = 3;
+  bytes signature = 4;
 }
 
 message Ping {}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -13,6 +13,7 @@ mod tests {
             sender: "alice".into(),
             recipient: "bob".into(),
             amount: 10,
+            signature: Vec::new(),
         };
         let mut buf = Vec::new();
         tx.encode(&mut buf).unwrap();
@@ -35,6 +36,7 @@ mod tests {
                 sender: "alice".into(),
                 recipient: "bob".into(),
                 amount: 10,
+                signature: Vec::new(),
             }],
         };
         let mut buf = Vec::new();

--- a/wallet/src/bip32.rs
+++ b/wallet/src/bip32.rs
@@ -157,6 +157,10 @@ impl XPrv {
         }
     }
 
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.secret
+    }
+
     pub fn to_string(&self, prefix: Prefix) -> String {
         let secp = Secp256k1::new();
         let mut data = Vec::with_capacity(78);


### PR DESCRIPTION
## Summary
- extend protobuf with `signature` bytes
- sign and verify transactions using secp256k1
- verify signatures when validating blocks
- update tests to create signed transactions

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_6860bb163920832ea5737e61e87a686f