### PR TITLE
Add CLI interface for p2p node

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ The `coin-p2p` crate provides a simple command line interface. A miner can be
 started with:
 
 ```bash
-cargo run -p coin-p2p -- <port> miner
+cargo run -p coin-p2p -- --port <PORT> --node-type miner
 ```
+Replace `<PORT>` with the TCP port to listen on. Additional nodes can be run as
+`wallet` or `verifier` types using the same command structure:
 
-Replace `<port>` with the TCP port to listen on. Additional nodes can be run as
-`wallet` or `verifier` types using the same command structure.
+```bash
+cargo run -p coin-p2p -- --port 9000 --node-type wallet
+```
 
 ## Wallet Basics
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,3 +1,4 @@
+use clap::ValueEnum;
 use coin::{Block, BlockHeader, Blockchain, TransactionExt};
 use coin_proto::proto::{Chain, GetChain, GetPeers, NodeMessage, Peers, Ping, Pong, Transaction};
 use hex;
@@ -38,7 +39,7 @@ async fn read_with_timeout(socket: &mut TcpStream) -> bool {
         .is_ok()
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub enum NodeType {
     Wallet,
     Miner,

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -5,8 +5,10 @@ use coin_p2p::{Node, NodeType};
 
 #[derive(Parser)]
 struct Args {
+    #[arg(long)]
     port: u16,
-    role: String,
+    #[arg(long, value_enum)]
+    node_type: NodeType,
     #[arg(long, default_value = "chain.bin")]
     chain_file: String,
 }
@@ -15,13 +17,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let kind = match args.role.as_str() {
-        "wallet" => NodeType::Wallet,
-        "miner" => NodeType::Miner,
-        "verifier" => NodeType::Verifier,
-        _ => NodeType::Wallet,
-    };
-    let node = Node::new(args.port, kind);
+    let node = Node::new(args.port, args.node_type);
     if let Ok(chain) = Blockchain::load(&args.chain_file) {
         *node.chain_handle().lock().await = chain;
     }


### PR DESCRIPTION
## Summary
- add a `main.rs` binary for `coin-p2p`
- parse `--port` and `--node-type` via clap and launch the node
- derive `ValueEnum` for `NodeType`
- document CLI usage in the README

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_6860c3cf7af4832e9dc75beb04b5753b