### PR TITLE
Add YAML config for network setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,8 @@ dependencies = [
  "hex-literal",
  "miner",
  "prost",
+ "serde",
+ "serde_yaml",
  "sha2",
  "tokio",
 ]
@@ -404,6 +406,12 @@ checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -754,6 +762,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "secp256k1"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +783,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -897,6 +944,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,7 @@
+listeners:
+  - ip: "0.0.0.0"
+    port: 9000
+wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
+node_type: Miner
+min_peers: 1
+chain_file: "chain.bin"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -13,6 +13,8 @@ hex = "0.4"
 miner = { path = "../miner" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 
 [dev-dependencies]
 coin-wallet = { path = "../wallet" }

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -1,0 +1,40 @@
+use serde::Deserialize;
+use std::fs::File;
+use std::net::SocketAddr;
+
+use crate::NodeType;
+
+#[derive(Debug, Deserialize)]
+pub struct Listener {
+    pub ip: String,
+    pub port: u16,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    pub listeners: Vec<Listener>,
+    pub wallet_address: Option<String>,
+    pub node_type: NodeType,
+    #[serde(default)]
+    pub min_peers: usize,
+    #[serde(default = "default_chain_file")]
+    pub chain_file: String,
+}
+
+fn default_chain_file() -> String {
+    "chain.bin".to_string()
+}
+
+impl Config {
+    pub fn from_file(path: &str) -> anyhow::Result<Self> {
+        let file = File::open(path)?;
+        Ok(serde_yaml::from_reader(file)?)
+    }
+
+    pub fn listener_addrs(&self) -> Vec<SocketAddr> {
+        self.listeners
+            .iter()
+            .filter_map(|l| format!("{}:{}", l.ip, l.port).parse().ok())
+            .collect()
+    }
+}

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -1,33 +1,33 @@
 use anyhow::Result;
 use clap::Parser;
 use coin::Blockchain;
-use coin_p2p::{Node, NodeType};
+use coin_p2p::{Node, NodeType, config::Config};
 
 #[derive(Parser)]
 struct Args {
-    #[arg(long)]
-    port: u16,
-    #[arg(long, value_enum)]
-    node_type: NodeType,
-    #[arg(long, default_value_t = 1)]
-    min_peers: usize,
-    #[arg(long, default_value = "chain.bin")]
-    chain_file: String,
+    #[arg(long, default_value = "config.yaml")]
+    config: String,
 }
 
 #[cfg(not(tarpaulin))]
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
-    let node = Node::new(args.port, args.node_type, Some(args.min_peers));
-    if let Ok(chain) = Blockchain::load(&args.chain_file) {
+    let cfg = Config::from_file(&args.config)?;
+    let node = Node::new(
+        cfg.listener_addrs(),
+        cfg.node_type,
+        Some(cfg.min_peers),
+        cfg.wallet_address.clone(),
+    );
+    if let Ok(chain) = Blockchain::load(&cfg.chain_file) {
         *node.chain_handle().lock().await = chain;
     }
     let (_addrs, _rx) = node.start().await?;
     tokio::signal::ctrl_c().await?;
     let handle = node.chain_handle();
     let chain = handle.lock().await;
-    chain.save(&args.chain_file)?;
+    chain.save(&cfg.chain_file)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- move network and mining settings to YAML
- let Node bind to configured IP:port pairs
- support mining reward address from config
- load config file in `coin-p2p` main

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_68614e6e9d94832e9847bff8f4565d38