### PR TITLE
Implement halving and cap supply

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project aims to become a full-fledged coin system built with multiple crates. Protocol buffer definitions live in `coin-proto` and networking utilities live in `coin-p2p`. The main `coin` crate provides core blockchain functionality. Unit tests cover all functionality and code coverage is measured using `cargo tarpaulin`.
 
+Each coin is divisible into 100&nbsp;000&nbsp;000 units allowing for very small transfers.
+
 ## Block Structure
 
 Blocks contain a header and a list of transactions. The header stores:
@@ -18,11 +20,13 @@ calculating block hashes.
 ## Mining Protocol
 
 Mining starts with a candidate block created from all pending transactions.
-Miners add a coinbase transaction paying `BLOCK_SUBSIDY` to themselves and
-then repeatedly hash the block header while incrementing the `nonce` until the
-SHA256 digest has the required number of leading zero bytes, defined by the
-`difficulty` field. Once a valid block is produced it is broadcast to peers and
-appended to the local chain.
+Miners add a coinbase transaction paying the current block subsidy to
+themselves. The subsidy starts at 50 coins and halves every `HALVING_INTERVAL`
+(200,000) blocks until a maximum of 20 million coins have been issued.
+After inserting the coinbase transaction, miners repeatedly hash the block
+header while incrementing the `nonce` until the SHA256 digest has the required
+number of leading zero bytes, defined by the `difficulty` field. Once a valid
+block is produced it is broadcast to peers and appended to the local chain.
 
 ### Difficulty Adjustment
 

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -13,9 +13,10 @@ fn meets_difficulty(hash: &[u8], difficulty: u32) -> bool {
 pub fn mine_block(chain: &mut Blockchain, miner: &str) -> Block {
     let difficulty = chain.difficulty();
     let mut block = chain.candidate_block();
+    let reward = chain.block_subsidy();
     block
         .transactions
-        .insert(0, coinbase_transaction(miner.to_string()));
+        .insert(0, coinbase_transaction(miner.to_string(), reward));
     let mut h = Sha256::new();
     for tx in &block.transactions {
         h.update(tx.hash());
@@ -78,7 +79,7 @@ mod tests {
                 nonce: 0,
                 difficulty: 0,
             },
-            transactions: vec![coinbase_transaction(A1)],
+            transactions: vec![coinbase_transaction(A1, bc.block_subsidy())],
         });
         let mut tx = new_transaction(A1, A2, 1);
         sign_a1(&mut tx);
@@ -96,8 +97,8 @@ mod tests {
         let mut bc = Blockchain::new();
         assert_eq!(bc.balance(A1), 0);
         mine_block(&mut bc, A1);
-        assert_eq!(bc.balance(A1), coin::BLOCK_SUBSIDY as i64);
+        assert_eq!(bc.balance(A1), bc.block_subsidy() as i64);
         mine_block(&mut bc, A1);
-        assert_eq!(bc.balance(A1), (coin::BLOCK_SUBSIDY * 2) as i64);
+        assert_eq!(bc.balance(A1), (bc.block_subsidy() * 2) as i64);
     }
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -474,6 +474,7 @@ mod tests {
         let addr = addrs[0];
         {
             let mut chain = node.chain.lock().await;
+            let reward = chain.block_subsidy();
             chain.add_block(Block {
                 header: BlockHeader {
                     previous_hash: String::new(),
@@ -482,7 +483,7 @@ mod tests {
                     nonce: 0,
                     difficulty: 0,
                 },
-                transactions: vec![coinbase_transaction(A1.clone())],
+                transactions: vec![coinbase_transaction(A1.clone(), reward)],
             });
         }
         node.connect(addr).await.unwrap();
@@ -776,6 +777,7 @@ mod tests {
         let (_addrs, _rx) = node.start().await.unwrap();
         {
             let mut chain = node.chain.lock().await;
+            let reward = chain.block_subsidy();
             chain.add_block(Block {
                 header: BlockHeader {
                     previous_hash: String::new(),
@@ -784,7 +786,7 @@ mod tests {
                     nonce: 0,
                     difficulty: 0,
                 },
-                transactions: vec![coinbase_transaction(A1)],
+                transactions: vec![coinbase_transaction(A1, reward)],
             });
             let mut tx = Transaction {
                 sender: A1.into(),
@@ -812,6 +814,7 @@ mod tests {
         let (_m_addrs, _rx) = miner.start().await.unwrap();
         {
             let mut chain = miner.chain.lock().await;
+            let reward = chain.block_subsidy();
             chain.add_block(Block {
                 header: BlockHeader {
                     previous_hash: String::new(),
@@ -820,7 +823,7 @@ mod tests {
                     nonce: 0,
                     difficulty: 0,
                 },
-                transactions: vec![coinbase_transaction(A1)],
+                transactions: vec![coinbase_transaction(A1, reward)],
             });
             let mut tx = Transaction {
                 sender: A1.into(),


### PR DESCRIPTION
## Summary
- add constants for supply cap and halving interval
- implement dynamic block subsidy with halving
- add smallest unit constant
- update coinbase transaction API and uses
- document halving and divisibility

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_686156995990832eb55faab667c805ef