### PR TITLE
Add peer persistence and seeding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
+ "tempfile",
  "tokio",
 ]
 

--- a/config.yaml
+++ b/config.yaml
@@ -5,3 +5,6 @@ wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 node_type: Miner
 min_peers: 1
 chain_file: "chain.bin"
+seed_peers:
+  - "127.0.0.1:9001"
+peers_file: "peers.txt"

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 coin-proto = { path = "../proto" }
-tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "time", "macros", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "time", "macros", "signal", "fs"] }
 prost = "0.12"
 coin = { path = ".." }
 sha2 = "0.10"
@@ -19,3 +19,4 @@ serde_yaml = "0.9"
 [dev-dependencies]
 coin-wallet = { path = "../wallet" }
 hex-literal = "0.4"
+tempfile = "3"


### PR DESCRIPTION
## Summary
- store known peers on disk and reload them at startup
- allow specifying seed peers in the YAML configuration
- connect to seeds on launch and save peers on shutdown
- cover new functionality with tests

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_68615b8fa6b4832e9934185b57e26d80