### PR TITLE
Add YAML config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ be connected before a miner begins hashing and defaults to `1`. Additional nodes
 cargo run -p coin-p2p -- --port 9000 --node-type wallet
 ```
 
+## Configuration File
+
+Nodes load settings from a YAML file passed with `--config` (defaults to
+`config.yaml`). The repository includes an annotated example at
+`config.example.yaml`:
+
+```yaml
+# Example configuration for coin-p2p
+listeners:
+  - ip: "0.0.0.0"
+    port: 9000
+wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
+node_type: Miner
+min_peers: 1
+chain_file: "chain.bin"
+seed_peers:
+  - "127.0.0.1:9001"
+peers_file: "peers.txt"
+```
+
+Field descriptions:
+
+- `listeners` – network interfaces and ports to bind.
+- `wallet_address` – optional address used when mining rewards are paid.
+- `node_type` – one of `Miner`, `Wallet`, or `Verifier`.
+- `min_peers` – how many peers must be connected before mining or verifying.
+- `chain_file` – path to the saved blockchain.
+- `seed_peers` – peers contacted on startup for bootstrapping.
+- `peers_file` – file for persisting discovered peers.
+
 ## Wallet Basics
 
 The `coin-wallet` crate offers a BIP32 HD wallet implementation.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,17 @@
+# Example configuration for coin-p2p
+listeners:
+  - ip: "0.0.0.0"
+    port: 9000
+# Optional wallet address to receive mining rewards
+wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
+# Node type: Wallet, Miner or Verifier
+node_type: Miner
+# Minimum number of peers required before starting mining
+min_peers: 1
+# Where the blockchain is stored on disk
+chain_file: "chain.bin"
+# List of peers to connect to on startup
+seed_peers:
+  - "127.0.0.1:9001"
+# File storing discovered peers
+peers_file: "peers.txt"


### PR DESCRIPTION
## Summary
- add example YAML configuration file for the p2p node
- document each config field in the README

## Testing
- `cargo fmt`
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_6861697e8b1c832ea6c56b771635f050