### PR TITLE
Share meets_difficulty utility

### DIFF
--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -1,14 +1,6 @@
+use coin::meets_difficulty;
 use coin::{Block, BlockHeader, Blockchain, TransactionExt, coinbase_transaction};
 use sha2::{Digest, Sha256};
-
-fn meets_difficulty(hash: &[u8], difficulty: u32) -> bool {
-    for i in 0..difficulty {
-        if hash.get(i as usize).copied().unwrap_or(0) != 0 {
-            return false;
-        }
-    }
-    true
-}
 
 pub fn mine_block(chain: &mut Blockchain, miner: &str) -> Block {
     let difficulty = chain.difficulty();

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use coin::meets_difficulty;
 use coin::{Block, BlockHeader, Blockchain, TransactionExt};
 use coin_proto::proto::{Chain, GetChain, GetPeers, NodeMessage, Peers, Ping, Pong, Transaction};
 use hex;
@@ -50,15 +51,6 @@ pub enum NodeType {
     Wallet,
     Miner,
     Verifier,
-}
-
-fn meets_difficulty(hash: &[u8], difficulty: u32) -> bool {
-    for i in 0..difficulty {
-        if hash.get(i as usize).copied().unwrap_or(0) != 0 {
-            return false;
-        }
-    }
-    true
 }
 
 fn valid_block(chain: &Blockchain, block: &Block) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+pub mod utils;
+pub use utils::meets_difficulty;
+
 /// Number of blocks used for difficulty adjustment
 pub const DIFFICULTY_WINDOW: usize = 3;
 /// Target time between blocks in seconds

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,8 @@
+pub fn meets_difficulty(hash: &[u8], difficulty: u32) -> bool {
+    for i in 0..difficulty {
+        if hash.get(i as usize).copied().unwrap_or(0) != 0 {
+            return false;
+        }
+    }
+    true
+}


### PR DESCRIPTION
## Summary
- move `meets_difficulty` helper into `coin::utils`
- use the shared version in `miner` and `p2p`

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_68616d4950dc832ebd1eb6df76f301ec