### PR TITLE
Add transaction fee support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ by converting a derived key into a `k256::ecdsa::SigningKey`:
 
 ```rust
 use coin_wallet::Wallet;
-use coin::new_transaction;
+use coin::new_transaction_with_fee;
 use k256::ecdsa::{signature::Signer, SigningKey};
 use sha2::{Digest, Sha256};
 
 let wallet = Wallet::generate("").unwrap();
-let tx = new_transaction("alice", "bob", 5);
+let tx = new_transaction_with_fee("alice", "bob", 5, 0);
 let hash = Sha256::digest(tx.hash().as_bytes());
 let child = wallet.derive_priv("m/0'/0/0").unwrap();
 let signer: SigningKey = (&child).into();

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -523,6 +523,7 @@ mod tests {
             sender: A1.into(),
             recipient: A2.into(),
             amount: 1,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -593,6 +594,7 @@ mod tests {
                 sender: A1.into(),
                 recipient: A2.into(),
                 amount: 2,
+                fee: 0,
                 signature: Vec::new(),
                 encrypted_message: Vec::new(),
             };
@@ -635,6 +637,7 @@ mod tests {
             sender: A1.into(),
             recipient: A2.into(),
             amount: 3,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -674,6 +677,7 @@ mod tests {
             sender: A1.into(),
             recipient: A2.into(),
             amount: 1,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -731,6 +735,7 @@ mod tests {
             sender: A1.into(),
             recipient: A2.into(),
             amount: 2,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -765,6 +770,7 @@ mod tests {
             sender: A1.into(),
             recipient: A2.into(),
             amount: 1,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -777,6 +783,7 @@ mod tests {
             sender: A2.into(),
             recipient: A1.into(),
             amount: 2,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -830,6 +837,7 @@ mod tests {
                 sender: A1.into(),
                 recipient: A2.into(),
                 amount: 1,
+                fee: 0,
                 signature: Vec::new(),
                 encrypted_message: Vec::new(),
             };
@@ -868,6 +876,7 @@ mod tests {
                 sender: A1.into(),
                 recipient: A2.into(),
                 amount: 1,
+                fee: 0,
                 signature: Vec::new(),
                 encrypted_message: Vec::new(),
             };

--- a/proto/proto/transaction.proto
+++ b/proto/proto/transaction.proto
@@ -5,6 +5,7 @@ message Transaction {
   string sender = 1;
   string recipient = 2;
   uint64 amount = 3;
+  uint64 fee = 6;
   bytes signature = 4;
   bytes encrypted_message = 5;
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -13,6 +13,7 @@ mod tests {
             sender: "alice".into(),
             recipient: "bob".into(),
             amount: 10,
+            fee: 0,
             signature: Vec::new(),
             encrypted_message: Vec::new(),
         };
@@ -37,6 +38,7 @@ mod tests {
                 sender: "alice".into(),
                 recipient: "bob".into(),
                 amount: 10,
+                fee: 0,
                 signature: Vec::new(),
                 encrypted_message: Vec::new(),
             }],


### PR DESCRIPTION
## Summary
- extend the protobuf Transaction message to include a `fee` field
- provide new helpers for fee-aware transactions
- incorporate fees in hashing and blockchain accounting
- include fees in miner rewards
- update documentation and tests

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_686175e5c0e4832e998764f22d8af666