### PR TITLE
Allow genesis mining with zero peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ started with:
 cargo run -p coin-p2p -- --port <PORT> --node-type miner [--min-peers N]
 ```
 Replace `<PORT>` with the TCP port to listen on. `--min-peers` controls how many peers must
-be connected before a miner begins hashing and defaults to `1`. Additional nodes can be run as
+be connected before a miner begins hashing and defaults to `1`. The first miner can
+run with `--min-peers 0` and will mine a genesis block even without pending transactions.
+Additional nodes can be run as
 `wallet` or `verifier` types using the same command structure:
 
 ```bash

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -382,7 +382,7 @@ impl Node {
                     }
                     {
                         let mut chain = chain.lock().await;
-                        if chain.mempool_len() > 0 {
+                        if chain.len() == 0 || chain.mempool_len() > 0 {
                             let block = mine_block(&mut chain, &reward);
                             broadcast_block_internal(peers.clone(), &block).await;
                         }
@@ -807,6 +807,21 @@ mod tests {
         let mut bad = block.clone();
         bad.header.merkle_root = String::new();
         assert!(!valid_block(&chain, &bad));
+    }
+
+    #[tokio::test]
+    async fn miner_mines_genesis_block() {
+        let miner = Node::with_interval(
+            vec!["0.0.0.0:0".parse().unwrap()],
+            Duration::from_millis(50),
+            NodeType::Miner,
+            Some(0),
+            Some(A1.to_string()),
+            None,
+        );
+        let (_addrs, _rx) = miner.start().await.unwrap();
+        sleep(Duration::from_millis(200)).await;
+        assert_eq!(miner.chain_len().await, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- let miners start hashing even with an empty chain
- test that a solo miner produces the genesis block
- document starting the first miner with `--min-peers 0`

## Testing
- `cargo fmt`
- `cargo test -p coin-p2p --quiet`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_68617ad6bc10832ea02be73028e383c0