### PR TITLE
Implement rate limiting in p2p node

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,3 +15,4 @@ seed_peers:
   - "127.0.0.1:9001"
 # File storing discovered peers
 peers_file: "peers.txt"
+max_msgs_per_sec: 10

--- a/config.yaml
+++ b/config.yaml
@@ -8,3 +8,4 @@ chain_file: "chain.bin"
 seed_peers:
   - "127.0.0.1:9001"
 peers_file: "peers.txt"
+max_msgs_per_sec: 10

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -27,6 +27,8 @@ pub struct Config {
     pub network_id: String,
     #[serde(default = "default_protocol_version")]
     pub protocol_version: u32,
+    #[serde(default = "default_max_msgs_per_sec")]
+    pub max_msgs_per_sec: u32,
 }
 
 fn default_chain_file() -> String {
@@ -43,6 +45,10 @@ fn default_network_id() -> String {
 
 fn default_protocol_version() -> u32 {
     1
+}
+
+fn default_max_msgs_per_sec() -> u32 {
+    10
 }
 
 impl Config {
@@ -86,5 +92,6 @@ peers_file: "p.txt"
         assert_eq!(cfg.peers_file, "p.txt");
         assert_eq!(cfg.network_id, "coin");
         assert_eq!(cfg.protocol_version, 1);
+        assert_eq!(cfg.max_msgs_per_sec, 10);
     }
 }

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -22,6 +22,7 @@ async fn main() -> Result<()> {
         Some(cfg.peers_file.clone()),
         Some(cfg.network_id.clone()),
         Some(cfg.protocol_version),
+        Some(cfg.max_msgs_per_sec),
     );
     if let Ok(chain) = Blockchain::load(&cfg.chain_file) {
         *node.chain_handle().lock().await = chain;


### PR DESCRIPTION
## Summary
- track per-peer message timestamps in `Node`
- disconnect peers exceeding configurable `max_msgs_per_sec`
- expose `max_msgs_per_sec` in config files and parser
- test rate limit enforcement

## Testing
- `cargo test -p coin-p2p -- --test-threads=1 --nocapture`
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: cargo-tarpaulin not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861869bd2ac832e9c7de2c7ff20c428