### PR TITLE
Support GetBlock RPC message

### DIFF
--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -28,6 +28,11 @@ pub struct Peers {
 pub struct GetChain;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct GetBlock {
+    pub hash: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Chain {
     pub blocks: Vec<Block>,
 }
@@ -62,6 +67,7 @@ pub enum NodeMessage {
     GetPeers(GetPeers),
     Peers(Peers),
     GetChain(GetChain),
+    GetBlock(GetBlock),
     Chain(Chain),
     Block(Block),
     Handshake(Handshake),


### PR DESCRIPTION
## Summary
- define `GetBlock` request in proto
- add `NodeMessage::GetBlock` and handler in P2P node
- respond with the requested block if it exists
- test request/response for existing and missing blocks

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_6861d8d68234832eb1c3a0e6c40b0cea