### PR TITLE
Add Merkle tree hashing and block pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ Each coin is divisible into 100&nbsp;000&nbsp;000 units allowing for very small 
 Blocks contain a header and a list of transactions. The header stores:
 
 - `previous_hash` – SHA256 hash of the preceding block
-- `merkle_root` – hash of all transactions in the block
+- `merkle_root` – root of a Merkle tree over all transactions
 - `timestamp` – seconds since the Unix epoch
 - `nonce` – value modified by miners to satisfy difficulty
 - `difficulty` – number of leading zero bits required in the block hash
 
 The main crate exposes helper methods for constructing transactions and
 calculating block hashes.
+
+Old blocks can prune stored transactions once they are buried under enough
+confirmations. Because only the Merkle root is included in the block hash,
+discarding transaction data does not invalidate the chain.
 
 ## Mining Protocol
 


### PR DESCRIPTION
## Summary
- implement Merkle tree calculation and pruning helpers
- update block hashing to exclude transactions
- compute Merkle roots when building or mining blocks
- allow pruning old blocks
- document new Merkle root behavior
- test Merkle tree root calculation and pruning

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: `cargo tarpaulin` not fully supported in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6861d9e3fe2c832e98f2b9bb5b9d13af