### PR TITLE
Fix ipv6 listener parsing and binary peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +202,7 @@ name = "coin-p2p"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode",
  "clap",
  "coin",
  "coin-proto",

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ min_peers: 1
 chain_file: "chain.bin"
 seed_peers:
   - "127.0.0.1:9001"
-peers_file: "peers.txt"
 ```
 
 Field descriptions:
@@ -85,7 +84,6 @@ Field descriptions:
 - `min_peers` – how many peers must be connected before mining or verifying.
 - `chain_file` – path to the saved blockchain.
 - `seed_peers` – peers contacted on startup for bootstrapping.
-- `peers_file` – file for persisting discovered peers.
 
 ## Tor Usage
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,8 +13,6 @@ chain_file: "chain.bin"
 # List of peers to connect to on startup
 seed_peers:
   - "127.0.0.1:9001"
-# File storing discovered peers
-peers_file: "peers.txt"
 max_msgs_per_sec: 10
 max_peers: 32
 mining_threads: 1

--- a/config.yaml
+++ b/config.yaml
@@ -7,7 +7,6 @@ min_peers: 1
 chain_file: "chain.bin"
 seed_peers:
   - "127.0.0.1:9001"
-peers_file: "peers.txt"
 max_msgs_per_sec: 10
 max_peers: 32
 mining_threads: 1

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 tokio-socks = "0.5"
+bincode = "1"
 
 [dev-dependencies]
 coin-wallet = { path = "../wallet" }

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use coin::Blockchain;
-use coin_p2p::{Node, NodeType, config::Config};
+use coin_p2p::{Node, config::Config};
 use std::io::{self, Write};
 use tokio::time::{Duration, sleep};
 
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
         cfg.node_type,
         Some(cfg.min_peers),
         cfg.wallet_address.clone(),
-        Some(cfg.peers_file.clone()),
+        None,
         tor_proxy,
         Some(cfg.network_id.clone()),
         Some(cfg.protocol_version),


### PR DESCRIPTION
## Summary
- parse IPv6 listeners correctly
- store peers list in a binary file with fixed filename
- remove `peers_file` from config files and docs
- add default for `min_peers` in config
- update examples and tests

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_6861fb2a882c832e9a1b3ec1f6f206a3