### PR TITLE
Update blockchain storage defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ listeners:
     port: 9000
 wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 node_type: Miner
-chain_file: "chain.bin"
+chain_file: "blocks/blockchain.dat"
 seed_peers:
   - "127.0.0.1:9001"
 ```

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -7,7 +7,7 @@ wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 # Node type: Wallet, Miner or Verifier
 node_type: Miner
 # Where the blockchain is stored on disk
-chain_file: "chain.bin"
+chain_file: "blocks/blockchain.dat"
 # List of peers to connect to on startup
 seed_peers:
   - "127.0.0.1:9001"

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ listeners:
     port: 9000
 wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 node_type: Miner
-chain_file: "chain.bin"
+chain_file: "blocks/blockchain.dat"
 seed_peers:
   - "127.0.0.1:9001"
 max_msgs_per_sec: 10

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -34,7 +34,7 @@ pub struct Config {
 }
 
 fn default_chain_file() -> String {
-    "chain.bin".to_string()
+    "blocks/blockchain.dat".to_string()
 }
 
 fn default_network_id() -> String {

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -18,6 +18,9 @@ struct Args {
 async fn main() -> Result<()> {
     let args = Args::parse();
     let cfg = Config::from_file(&args.config)?;
+    if let Some(parent) = std::path::Path::new(&cfg.chain_file).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     let tor_proxy = args
         .tor_proxy
         .or(cfg.tor_proxy.clone())
@@ -61,6 +64,9 @@ async fn main() -> Result<()> {
     node.shutdown();
     let handle = node.chain_handle();
     let chain = handle.lock().await;
+    if let Some(parent) = std::path::Path::new(&cfg.chain_file).parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     chain.save(&cfg.chain_file)?;
     node.save_peers().await?;
     Ok(())


### PR DESCRIPTION
## Summary
- set `blocks/blockchain.dat` as the default chain file
- update example configs and docs
- create chain directory when running a node

## Testing
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_686205031d74832e87ed26583e945cbd