### PR TITLE
Add wallet CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +135,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -234,7 +261,12 @@ dependencies = [
 name = "coin-wallet"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "assert_cmd",
  "bs58",
+ "clap",
+ "coin",
+ "coin-proto",
  "hex",
  "hex-literal",
  "hmac",
@@ -242,7 +274,10 @@ dependencies = [
  "rand",
  "ripemd",
  "secp256k1",
+ "serde_json",
  "sha2",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -271,6 +306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +321,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "either"
@@ -529,6 +576,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +655,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 
 [[package]]
 name = "ripemd"
@@ -753,6 +833,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +942,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasi"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,27 @@ let signer: SigningKey = (&child).into();
 let sig = signer.sign(&hash);
 ```
 
+## Wallet CLI
+
+The `coin-wallet` crate includes a simple command line interface. Generate a new wallet and save the mnemonic with:
+
+```bash
+cargo run -p coin-wallet --bin cli -- generate --wallet my.mnemonic
+```
+
+Derive addresses or view balances via a running node:
+
+```bash
+cargo run -p coin-wallet --bin cli -- derive --wallet my.mnemonic --path "m/0'/0/0"
+cargo run -p coin-wallet --bin cli -- balance --address <ADDR> --node 127.0.0.1:9000
+```
+
+Transactions can be signed and broadcasted:
+
+```bash
+cargo run -p coin-wallet --bin cli -- send --to <ADDR> --amount 1 --path "m/0'/0/0" --node 127.0.0.1:9000
+```
+
 ## Development
 
 ```bash

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -9,9 +9,17 @@ hex = "0.4"
 bs58 = "0.5"
 sha2 = "0.10"
 ripemd = "0.1"
-secp256k1 = "0.27"
+secp256k1 = { version = "0.27", features = ["rand"] }
 pbkdf2 = "0.12"
 hmac = "0.12"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["net", "io-util", "macros", "rt-multi-thread"] }
+anyhow = "1"
+serde_json = "1"
+coin-proto = { path = "../proto" }
+coin = { path = ".." }
 
 [dev-dependencies]
 hex-literal = "0.4"
+assert_cmd = "2"
+tempfile = "3"

--- a/wallet/src/bin/cli.rs
+++ b/wallet/src/bin/cli.rs
@@ -1,0 +1,229 @@
+use anyhow::{Result, anyhow};
+use clap::{Parser, Subcommand};
+use coin::{Blockchain, TransactionExt, new_transaction_with_fee};
+use coin_proto::{Chain, GetChain, Handshake, NodeMessage, Transaction};
+use coin_wallet::Wallet;
+use rand::rngs::OsRng;
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, lookup_host};
+
+#[derive(Parser)]
+#[command(author, version, about)]
+struct Cli {
+    #[arg(long, default_value = "wallet.mnemonic")]
+    wallet: String,
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Generate a new wallet and save the mnemonic
+    Generate {},
+    /// Import a wallet from mnemonic
+    Import { phrase: String },
+    /// Derive an address from a BIP32 path
+    Derive { path: String },
+    /// Display balance for an address via RPC
+    Balance {
+        address: Option<String>,
+        path: Option<String>,
+        #[arg(long, default_value = "127.0.0.1:9000")]
+        node: String,
+    },
+    /// Sign and send a transaction
+    Send {
+        to: String,
+        amount: u64,
+        #[arg(long, default_value = "0")]
+        fee: u64,
+        path: String,
+        #[arg(long, default_value = "127.0.0.1:9000")]
+        node: String,
+    },
+}
+
+fn write_wallet(path: &str, phrase: &str) -> Result<()> {
+    std::fs::write(path, phrase).map_err(Into::into)
+}
+
+fn load_wallet(path: &str) -> Result<Wallet> {
+    let phrase = std::fs::read_to_string(path)?;
+    Ok(Wallet::from_mnemonic(&phrase, "").map_err(|e| anyhow!("{:?}", e))?)
+}
+
+fn sign_handshake(sk: &SecretKey, network_id: &str, version: u32) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(network_id.as_bytes());
+    hasher.update(version.to_be_bytes());
+    let hash = hasher.finalize();
+    let secp = Secp256k1::new();
+    let msg = secp256k1::Message::from_slice(&hash).expect("32 bytes");
+    let sig = secp.sign_ecdsa_recoverable(&msg, sk);
+    let (rec_id, data) = sig.serialize_compact();
+    let mut out = Vec::with_capacity(65);
+    out.push(rec_id.to_i32() as u8);
+    out.extend_from_slice(&data);
+    out
+}
+
+fn verify_handshake(h: &Handshake) -> bool {
+    if h.public_key.len() != 33 || h.signature.len() != 65 {
+        return false;
+    }
+    let pk = match PublicKey::from_slice(&h.public_key) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let rec_id = match secp256k1::ecdsa::RecoveryId::from_i32(h.signature[0] as i32) {
+        Ok(id) => id,
+        Err(_) => return false,
+    };
+    let mut data = [0u8; 64];
+    data.copy_from_slice(&h.signature[1..]);
+    let sig = match secp256k1::ecdsa::RecoverableSignature::from_compact(&data, rec_id) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    let mut hasher = Sha256::new();
+    hasher.update(h.network_id.as_bytes());
+    hasher.update(h.version.to_be_bytes());
+    let hash = hasher.finalize();
+    let msg = secp256k1::Message::from_slice(&hash).expect("32 bytes");
+    let secp = Secp256k1::new();
+    match secp.recover_ecdsa(&msg, &sig) {
+        Ok(p) => p == pk,
+        Err(_) => false,
+    }
+}
+
+async fn write_msg(stream: &mut TcpStream, msg: &NodeMessage) -> Result<()> {
+    let buf = serde_json::to_vec(msg)?;
+    let len = (buf.len() as u32).to_be_bytes();
+    stream.write_all(&len).await?;
+    stream.write_all(&buf).await?;
+    Ok(())
+}
+
+async fn read_msg(stream: &mut TcpStream) -> Result<NodeMessage> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await?;
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf).await?;
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+async fn rpc_connect(addr: &str) -> Result<TcpStream> {
+    let addr = lookup_host(addr)
+        .await?
+        .next()
+        .ok_or(anyhow!("invalid addr"))?;
+    let mut stream = TcpStream::connect(addr).await?;
+    let mut rng = OsRng;
+    let sk = SecretKey::new(&mut rng);
+    let secp = Secp256k1::new();
+    let pk = PublicKey::from_secret_key(&secp, &sk);
+    let hs = NodeMessage::Handshake(Handshake {
+        network_id: "coin".to_string(),
+        version: 1,
+        public_key: pk.serialize().to_vec(),
+        signature: sign_handshake(&sk, "coin", 1),
+    });
+    write_msg(&mut stream, &hs).await?;
+    match read_msg(&mut stream).await? {
+        NodeMessage::Handshake(h)
+            if h.network_id == "coin" && h.version == 1 && verify_handshake(&h) => {}
+        _ => return Err(anyhow!("handshake failed")),
+    }
+    Ok(stream)
+}
+
+async fn fetch_chain(addr: &str) -> Result<Vec<coin::Block>> {
+    let mut stream = rpc_connect(addr).await?;
+    let get = NodeMessage::GetChain(GetChain {});
+    write_msg(&mut stream, &get).await?;
+    loop {
+        match read_msg(&mut stream).await? {
+            NodeMessage::Chain(Chain { blocks }) => {
+                let chain: Vec<_> = blocks
+                    .into_iter()
+                    .filter_map(coin::Block::from_rpc)
+                    .collect();
+                return Ok(chain);
+            }
+            _ => continue,
+        }
+    }
+}
+
+async fn send_transaction(addr: &str, tx: &Transaction) -> Result<()> {
+    let mut stream = rpc_connect(addr).await?;
+    let msg = NodeMessage::Transaction(tx.clone());
+    write_msg(&mut stream, &msg).await?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Generate {} => {
+            let wallet = Wallet::generate("").map_err(|e| anyhow!("{:?}", e))?;
+            let phrase = wallet.mnemonic().unwrap().phrase().to_string();
+            write_wallet(&cli.wallet, &phrase)?;
+            println!("Mnemonic: {}", phrase);
+        }
+        Commands::Import { phrase } => {
+            let wallet = Wallet::from_mnemonic(&phrase, "").map_err(|e| anyhow!("{:?}", e))?;
+            write_wallet(&cli.wallet, wallet.mnemonic().unwrap().phrase())?;
+        }
+        Commands::Derive { path } => {
+            let wallet = load_wallet(&cli.wallet)?;
+            let addr = wallet
+                .derive_address(&path)
+                .map_err(|e| anyhow!("{:?}", e))?;
+            println!("{}", addr);
+        }
+        Commands::Balance {
+            address,
+            path,
+            node,
+        } => {
+            let addr = if let Some(a) = address {
+                a
+            } else if let Some(p) = path {
+                let wallet = load_wallet(&cli.wallet)?;
+                wallet.derive_address(&p).map_err(|e| anyhow!("{:?}", e))?
+            } else {
+                return Err(anyhow!("address or path required"));
+            };
+            let blocks = fetch_chain(&node).await?;
+            let mut bc = Blockchain::new();
+            for b in blocks {
+                bc.add_block(b);
+            }
+            println!("{}", bc.balance(&addr));
+        }
+        Commands::Send {
+            to,
+            amount,
+            fee,
+            path,
+            node,
+        } => {
+            let wallet = load_wallet(&cli.wallet)?;
+            let child = wallet.derive_priv(&path).map_err(|e| anyhow!("{:?}", e))?;
+            let from = wallet
+                .derive_address(&path)
+                .map_err(|e| anyhow!("{:?}", e))?;
+            let mut tx = new_transaction_with_fee(&from, to, amount, fee);
+            tx.sign(child.secret_key());
+            send_transaction(&node, &tx).await?;
+            println!("Transaction sent");
+        }
+    }
+    Ok(())
+}

--- a/wallet/tests/cli.rs
+++ b/wallet/tests/cli.rs
@@ -1,0 +1,22 @@
+use assert_cmd::Command;
+use tempfile;
+
+#[test]
+fn generate_and_derive() {
+    let dir = tempfile::tempdir().unwrap();
+    let wallet = dir.path().join("test.mnemonic");
+    Command::cargo_bin("cli")
+        .unwrap()
+        .args(["--wallet", wallet.to_str().unwrap(), "generate"])
+        .assert()
+        .success();
+    assert!(wallet.exists());
+    let out = Command::cargo_bin("cli")
+        .unwrap()
+        .args(["--wallet", wallet.to_str().unwrap(), "derive", "m/0'/0/0"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let addr = String::from_utf8(out.stdout).unwrap();
+    assert_eq!(addr.trim().len(), 34);
+}


### PR DESCRIPTION
## Summary
- add a wallet CLI using `clap`
- support basic wallet management and RPC interaction
- document CLI usage
- test CLI generation and address derivation

## Testing
- `cargo test -p coin-wallet`
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_6862cbedf908832eaa4746e4fb5178cd