### PR TITLE
Add blockfile persistence test

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -412,9 +412,8 @@ impl Node {
         let path = std::path::Path::new("mempool.bin");
         if path.exists() {
             let mut chain = self.chain.lock().await;
-            if chain.load_mempool(path).is_ok() {
-                let _ = std::fs::remove_file(path);
-            }
+            let _ = chain.load_mempool(path);
+            let _ = std::fs::remove_file(path);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,6 +840,30 @@ mod tests {
     }
 
     #[test]
+    fn save_creates_block_files() {
+        let mut bc = Blockchain::new();
+        for i in 0..2 {
+            let tx = coinbase_transaction(A1, bc.block_subsidy());
+            bc.add_block(Block {
+                header: BlockHeader {
+                    previous_hash: bc.last_block_hash().unwrap_or_default(),
+                    merkle_root: compute_merkle_root(&[tx.clone()]),
+                    timestamp: i,
+                    nonce: 0,
+                    difficulty: 0,
+                },
+                transactions: vec![tx],
+            });
+        }
+        let dir = tempfile::tempdir().unwrap();
+        bc.save(dir.path()).unwrap();
+        assert!(dir.path().join("blk00000.dat").exists());
+        assert!(dir.path().join("blk00001.dat").exists());
+        let loaded = Blockchain::load(dir.path()).unwrap();
+        assert_eq!(loaded.all(), bc.all());
+    }
+
+    #[test]
     fn load_rejects_invalid_chain() {
         let dir = tempfile::tempdir().unwrap();
         let block = Block {


### PR DESCRIPTION
## Summary
- ensure the mempool file is removed even if loading fails
- test that Blockchain::save writes separate block files for each block

## Testing
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_6862f5f23f98832eb2d639ca7aff89cc