### PR TITLE
Add handshake verification tests

### DIFF
--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -79,7 +79,7 @@ fn load_or_create_key(path: &str) -> (secp256k1::SecretKey, secp256k1::PublicKey
     (sk, pk)
 }
 
-fn sign_handshake(sk: &secp256k1::SecretKey, network_id: &str, version: u32) -> Vec<u8> {
+pub fn sign_handshake(sk: &secp256k1::SecretKey, network_id: &str, version: u32) -> Vec<u8> {
     let mut hasher = sha2::Sha256::new();
     hasher.update(network_id.as_bytes());
     hasher.update(version.to_be_bytes());
@@ -94,7 +94,7 @@ fn sign_handshake(sk: &secp256k1::SecretKey, network_id: &str, version: u32) -> 
     out
 }
 
-fn verify_handshake(h: &Handshake) -> bool {
+pub fn verify_handshake(h: &Handshake) -> bool {
     if h.public_key.len() != 33 || h.signature.len() != 65 {
         return false;
     }

--- a/p2p/tests/handshake.rs
+++ b/p2p/tests/handshake.rs
@@ -1,0 +1,84 @@
+use coin_p2p::{Node, NodeType, sign_handshake, verify_handshake};
+use coin_proto::Handshake;
+use rand::rngs::OsRng;
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+
+#[test]
+fn sign_and_verify_roundtrip() {
+    let mut rng = OsRng;
+    let sk = SecretKey::new(&mut rng);
+    let pk = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
+    let sig = sign_handshake(&sk, "coin", 1);
+    let hs = Handshake {
+        network_id: "coin".into(),
+        version: 1,
+        public_key: pk.serialize().to_vec(),
+        signature: sig,
+    };
+    assert!(verify_handshake(&hs));
+}
+
+#[test]
+fn verify_detects_tampered_sig() {
+    let mut rng = OsRng;
+    let sk = SecretKey::new(&mut rng);
+    let pk = PublicKey::from_secret_key(&Secp256k1::new(), &sk);
+    let mut sig = sign_handshake(&sk, "coin", 1);
+    sig[0] ^= 0x01;
+    let hs = Handshake {
+        network_id: "coin".into(),
+        version: 1,
+        public_key: pk.serialize().to_vec(),
+        signature: sig,
+    };
+    assert!(!verify_handshake(&hs));
+}
+
+#[tokio::test]
+async fn node_rejects_mismatched_handshake() {
+    let node_a = Node::new(
+        vec!["0.0.0.0:0".parse().unwrap()],
+        NodeType::Wallet,
+        None,
+        None,
+        None,
+        None,
+        Some("net1".into()),
+        Some(1),
+        None,
+        None,
+        None,
+    );
+    let (addrs, _) = node_a.start().await.unwrap();
+    let addr = addrs[0];
+    let node_b = Node::new(
+        vec!["0.0.0.0:0".parse().unwrap()],
+        NodeType::Wallet,
+        None,
+        None,
+        None,
+        None,
+        Some("net2".into()),
+        Some(1),
+        None,
+        None,
+        None,
+    );
+    assert!(node_b.connect(addr).await.is_err());
+    assert!(node_b.peers().await.is_empty());
+    let node_c = Node::new(
+        vec!["0.0.0.0:0".parse().unwrap()],
+        NodeType::Wallet,
+        None,
+        None,
+        None,
+        None,
+        Some("net1".into()),
+        Some(2),
+        None,
+        None,
+        None,
+    );
+    assert!(node_c.connect(addr).await.is_err());
+    assert!(node_c.peers().await.is_empty());
+}


### PR DESCRIPTION
## Summary
- expose handshake sign and verify functions
- test handshake signing and verification
- test node handshake mismatch handling

## Testing
- `cargo test -p coin-p2p`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_686316e75654832e9a56a70376f9e225