### PR TITLE
Switch timestamps to ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Blocks contain a header and a list of transactions. The header stores:
 
 - `previous_hash` – SHA256 hash of the preceding block
 - `merkle_root` – root of a Merkle tree over all transactions
-- `timestamp` – seconds since the Unix epoch
+- `timestamp` – milliseconds since the Unix epoch
 - `nonce` – value modified by miners to satisfy difficulty
 - `difficulty` – number of leading zero bits required in the block hash
 
@@ -35,7 +35,7 @@ block is produced it is broadcast to peers and appended to the local chain.
 ### Difficulty Adjustment
 
 `DIFFICULTY_WINDOW` recent blocks are examined each time a new block is added.
-If the average spacing between them is less than `TARGET_BLOCK_TIME` the
+If the average spacing between them is less than `TARGET_BLOCK_MS` the
 difficulty is increased; if it is greater, the difficulty decreases. This keeps
 block production close to the target interval.
 

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -27,7 +27,7 @@ pub mod rpc;
 const DEFAULT_MAX_MSGS_PER_SEC: u32 = 10;
 const DEFAULT_MAX_PEERS: usize = 32;
 const MAX_MSG_BYTES: usize = 1024 * 1024; // 1 MiB
-const MAX_TIME_DRIFT_SECS: i64 = 2 * 60 * 60; // 2 hours
+const MAX_TIME_DRIFT_MS: i64 = 2 * 60 * 60 * 1000; // 2 hours
 
 /// Send a length-prefixed JSON-RPC message over the socket
 async fn write_msg(socket: &mut TcpStream, msg: &RpcMessage) -> tokio::io::Result<()> {
@@ -138,9 +138,9 @@ fn valid_block(chain: &Blockchain, block: &Block) -> bool {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
-        .as_secs() as i64;
+        .as_millis() as i64;
     let ts = block.header.timestamp as i64;
-    if (ts - now).abs() > MAX_TIME_DRIFT_SECS {
+    if (ts - now).abs() > MAX_TIME_DRIFT_MS {
         return false;
     }
     if let Some(prev) = chain.all().last() {
@@ -1238,7 +1238,7 @@ mod tests {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs();
+            .as_millis() as u64;
         let block_msg = RpcMessage::Block(coin_proto::Block {
             header: coin_proto::BlockHeader {
                 previous_hash: String::new(),
@@ -1307,7 +1307,7 @@ mod tests {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs();
+            .as_millis() as u64;
         let block = Block {
             header: BlockHeader {
                 previous_hash: String::new(),
@@ -1396,12 +1396,12 @@ mod tests {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs();
+            .as_millis() as u64;
         let future_block = Block {
             header: BlockHeader {
                 previous_hash: chain.last_block_hash().unwrap(),
                 merkle_root: merkle.clone(),
-                timestamp: now + (MAX_TIME_DRIFT_SECS as u64) + 1,
+                timestamp: now + (MAX_TIME_DRIFT_MS as u64) + 1,
                 nonce: 0,
                 difficulty: 0,
             },
@@ -1413,7 +1413,7 @@ mod tests {
             header: BlockHeader {
                 previous_hash: chain.last_block_hash().unwrap(),
                 merkle_root: merkle.clone(),
-                timestamp: now - (MAX_TIME_DRIFT_SECS as u64) - 1,
+                timestamp: now - (MAX_TIME_DRIFT_MS as u64) - 1,
                 nonce: 0,
                 difficulty: 0,
             },

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -57,6 +57,7 @@ pub struct Chain {
 pub struct BlockHeader {
     pub previous_hash: String,
     pub merkle_root: String,
+    /// Milliseconds since the Unix epoch
     pub timestamp: u64,
     pub nonce: u64,
     pub difficulty: u32,


### PR DESCRIPTION
## Summary
- represent block times in milliseconds
- adapt `candidate_block` to record ms
- adjust difficulty to compare millisecond intervals
- use ms for time drift checks in P2P
- document millisecond timestamps

## Testing
- `cargo test`
- `cargo test -p coin-p2p`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`

------
https://chatgpt.com/codex/tasks/task_e_68631dfbb8d0832ea90c3edcb6b7bb1a