### PR TITLE
Improve default mining threads and add benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +210,33 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -318,6 +366,46 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -450,6 +538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +558,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -493,10 +597,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -544,6 +668,7 @@ version = "0.1.0"
 dependencies = [
  "coin",
  "coin-wallet",
+ "criterion",
  "hex",
  "hex-literal",
  "sha2",
@@ -598,6 +723,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pbkdf2"
@@ -776,10 +907,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -832,6 +980,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "secp256k1"
@@ -996,6 +1153,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1263,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Field descriptions:
 - `node_type` – one of `Miner`, `Wallet`, or `Verifier`.
 - `block_dir` – directory where block files are stored.
 - `seed_peers` – peers contacted on startup for bootstrapping.
+- `mining_threads` – optional number of threads used for mining. When omitted,
+  the miner automatically utilizes all available CPU cores. Faster hardware or
+  more threads will generally lead to shorter block times.
 
 ## Tor Usage
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,8 @@ block_dir: "blocks"
 seed_peers:
   - "127.0.0.1:9001"
 max_msgs_per_sec: 10
+# mining_threads is optional. When omitted, all CPU cores are used.
 max_peers: 32
-mining_threads: 1
+# mining_threads: 4
 # Optional SOCKS5 proxy (Tor). Example: "127.0.0.1:9050"
 tor_proxy: null

--- a/config.yaml
+++ b/config.yaml
@@ -8,5 +8,7 @@ seed_peers:
   - "127.0.0.1:9001"
 max_msgs_per_sec: 10
 max_peers: 32
-mining_threads: 1
+# mining_threads controls the number of CPU threads used for mining.
+# When omitted the software automatically uses all available cores.
+# mining_threads: 4
 tor_proxy: null

--- a/miner/Cargo.toml
+++ b/miner/Cargo.toml
@@ -11,3 +11,8 @@ hex = "0.4"
 [dev-dependencies]
 coin-wallet = { path = "../wallet" }
 hex-literal = "0.4"
+criterion = { version = "0.5", default-features = false }
+
+[[bench]]
+name = "mining"
+harness = false

--- a/miner/benches/mining.rs
+++ b/miner/benches/mining.rs
@@ -1,0 +1,42 @@
+use coin::{Block, BlockHeader, Blockchain, coinbase_transaction};
+use criterion::{Criterion, criterion_group, criterion_main};
+use miner::mine_block_threads;
+
+fn setup_chain() -> Blockchain {
+    let mut bc = Blockchain::new();
+    bc.add_block(Block {
+        header: BlockHeader {
+            previous_hash: String::new(),
+            merkle_root: String::new(),
+            timestamp: 0,
+            nonce: 0,
+            difficulty: 0,
+        },
+        transactions: vec![coinbase_transaction("bench", bc.block_subsidy())],
+    });
+    bc
+}
+
+fn bench_single_thread(c: &mut Criterion) {
+    c.bench_function("mine_1_thread", |b| {
+        b.iter(|| {
+            let mut bc = setup_chain();
+            mine_block_threads(&mut bc, "bench", 1);
+        });
+    });
+}
+
+fn bench_multi_thread(c: &mut Criterion) {
+    let threads = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(2);
+    c.bench_function(&format!("mine_{}_threads", threads), |b| {
+        b.iter(|| {
+            let mut bc = setup_chain();
+            mine_block_threads(&mut bc, "bench", threads);
+        });
+    });
+}
+
+criterion_group!(benches, bench_single_thread, bench_multi_thread);
+criterion_main!(benches);

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -29,8 +29,8 @@ pub struct Config {
     pub max_msgs_per_sec: u32,
     #[serde(default = "default_max_peers")]
     pub max_peers: usize,
-    #[serde(default = "default_mining_threads")]
-    pub mining_threads: usize,
+    #[serde(default)]
+    pub mining_threads: Option<usize>,
 }
 
 fn default_block_dir() -> String {
@@ -51,12 +51,6 @@ fn default_max_msgs_per_sec() -> u32 {
 
 fn default_max_peers() -> usize {
     32
-}
-
-fn default_mining_threads() -> usize {
-    std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
 }
 
 impl Config {
@@ -106,7 +100,7 @@ seed_peers:
         assert_eq!(cfg.protocol_version, 1);
         assert_eq!(cfg.max_msgs_per_sec, 10);
         assert_eq!(cfg.max_peers, 32);
-        assert!(cfg.mining_threads >= 1);
+        assert!(cfg.mining_threads.is_none());
         assert!(cfg.tor_proxy.is_none());
         assert_eq!(cfg.block_dir, "blocks");
     }

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<()> {
         Some(cfg.protocol_version),
         Some(cfg.max_msgs_per_sec),
         Some(cfg.max_peers),
-        Some(cfg.mining_threads),
+        cfg.mining_threads,
     );
     if let Ok(chain) = Blockchain::load(&cfg.block_dir) {
         *node.chain_handle().lock().await = chain;


### PR DESCRIPTION
## Summary
- make `mining_threads` optional in config
- use all CPU cores if `mining_threads` not specified
- add criterion benchmark comparing thread counts
- document optional mining threads and hardware effect
- update example config

## Testing
- `cargo fmt`
- `cargo test`
- `cargo bench --no-run -p miner`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_686328e67764832e9c47e00c6f350e49