### PR TITLE
Integrate HTTP API with node RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,10 +318,13 @@ dependencies = [
 name = "coin-http"
 version = "0.1.0"
 dependencies = [
+ "coin",
  "coin-p2p",
  "coin-proto",
  "hyper",
+ "rand 0.8.5",
  "reqwest",
+ "secp256k1",
  "serde",
  "serde_json",
  "tokio",

--- a/http-api/Cargo.toml
+++ b/http-api/Cargo.toml
@@ -4,12 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "time"] }
 hyper = { version = "0.14", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 coin-proto = { path = "../proto" }
 coin-p2p = { path = "../p2p" }
+secp256k1 = { version = "0.27", features = ["recovery", "rand"] }
+rand = "0.8"
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+coin = { path = ".." }

--- a/http-api/tests/http_api.rs
+++ b/http-api/tests/http_api.rs
@@ -1,3 +1,5 @@
+use coin::{Block, BlockHeader, coinbase_transaction};
+use coin_p2p::{Node, NodeType};
 use coin_proto::Transaction;
 use reqwest::Client;
 use serde_json::Value;
@@ -5,15 +7,53 @@ use tokio::task;
 
 #[tokio::test]
 async fn test_http_endpoints() {
-    let addr = "127.0.0.1:0";
-    // start server on random port
-    let listener = std::net::TcpListener::bind(addr).unwrap();
+    let node = Node::new(
+        vec!["0.0.0.0:0".parse().unwrap()],
+        NodeType::Wallet,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    );
+    let reward;
+    {
+        let handle = node.chain_handle();
+        let mut chain = handle.lock().await;
+        reward = chain.block_subsidy();
+        chain.add_block(Block {
+            header: BlockHeader {
+                previous_hash: String::new(),
+                merkle_root: String::new(),
+                timestamp: 0,
+                nonce: 0,
+                difficulty: 0,
+            },
+            transactions: vec![coinbase_transaction(
+                "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr",
+                reward,
+            )],
+        });
+    }
+    let (addrs, _) = node.start().await.unwrap();
+    let node_addr = addrs[0];
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = listener.local_addr().unwrap();
     let server = task::spawn(async move {
         hyper::Server::from_tcp(listener)
             .unwrap()
-            .serve(hyper::service::make_service_fn(|_| async {
-                Ok::<_, std::convert::Infallible>(hyper::service::service_fn(coin_http::handle_req))
+            .serve(hyper::service::make_service_fn(move |_| {
+                let node_addr = node_addr;
+                async move {
+                    Ok::<_, std::convert::Infallible>(hyper::service::service_fn(move |req| {
+                        coin_http::handle_req(req, node_addr)
+                    }))
+                }
             }))
             .await
             .unwrap();
@@ -21,13 +61,17 @@ async fn test_http_endpoints() {
 
     let client = Client::new();
     let resp = client
-        .get(&format!("http://{}/getBalance/alice", addr))
+        .get(&format!(
+            "http://{}/getBalance/1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr",
+            addr
+        ))
         .send()
         .await
         .unwrap();
     assert!(resp.status().is_success());
     let v: Value = resp.json().await.unwrap();
-    assert_eq!(v["method"], "getBalance");
+    assert_eq!(v["method"], "balance");
+    assert_eq!(v["params"]["amount"].as_i64().unwrap(), reward as i64);
 
     let tx = Transaction {
         sender: "a".into(),
@@ -46,17 +90,17 @@ async fn test_http_endpoints() {
         .await
         .unwrap();
     assert!(resp.status().is_success());
-    let v: Value = resp.json().await.unwrap();
-    assert_eq!(v["method"], "transaction");
+    assert!(resp.text().await.unwrap().is_empty());
 
     let resp = client
-        .get(&format!("http://{}/getBlocks/1/2", addr))
+        .get(&format!("http://{}/getBlocks/0/0", addr))
         .send()
         .await
         .unwrap();
     assert!(resp.status().is_success());
     let v: Value = resp.json().await.unwrap();
-    assert_eq!(v["method"], "getBlocks");
+    assert_eq!(v["method"], "chain");
+    assert_eq!(v["params"]["blocks"].as_array().unwrap().len(), 1);
 
     server.abort();
 }

--- a/http-api/tests/http_api.rs
+++ b/http-api/tests/http_api.rs
@@ -1,6 +1,7 @@
 use coin::{Block, BlockHeader, coinbase_transaction};
 use coin_p2p::{Node, NodeType};
 use coin_proto::Transaction;
+use hyper::{Body, Method, Request, StatusCode};
 use reqwest::Client;
 use serde_json::Value;
 use tokio::task;
@@ -101,6 +102,95 @@ async fn test_http_endpoints() {
     let v: Value = resp.json().await.unwrap();
     assert_eq!(v["method"], "chain");
     assert_eq!(v["params"]["blocks"].as_array().unwrap().len(), 1);
+
+    server.abort();
+}
+
+#[tokio::test]
+async fn test_send_transaction_invalid_json() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/sendTransaction")
+        .body(Body::from("oops"))
+        .unwrap();
+    let resp = coin_http::handle_req(req, "127.0.0.1:1".parse().unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_get_blocks_bad_path() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/getBlocks/1")
+        .body(Body::empty())
+        .unwrap();
+    let resp = coin_http::handle_req(req, "127.0.0.1:1".parse().unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_not_found_path() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/unknown")
+        .body(Body::empty())
+        .unwrap();
+    let resp = coin_http::handle_req(req, "127.0.0.1:1".parse().unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_rpc_error() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/getBalance/alice")
+        .body(Body::empty())
+        .unwrap();
+    let resp = coin_http::handle_req(req, "127.0.0.1:1".parse().unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn test_forward_rpc_timeout() {
+    use coin_p2p::rpc::{RpcMessage, read_rpc, write_rpc};
+    use coin_proto::Handshake;
+    use tokio::net::TcpListener;
+    use tokio::time::{Duration, sleep};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.unwrap();
+        let _ = read_rpc(&mut stream).await.unwrap();
+        let reply = RpcMessage::Handshake(Handshake {
+            network_id: "coin".into(),
+            version: 1,
+            public_key: vec![],
+            signature: vec![],
+        });
+        write_rpc(&mut stream, &reply).await.unwrap();
+        sleep(Duration::from_secs(2)).await;
+    });
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/getBalance/alice")
+        .body(Body::empty())
+        .unwrap();
+    let resp = coin_http::handle_req(req, addr).await.unwrap();
+    assert!(resp.status().is_success());
+    assert_eq!(
+        hyper::body::to_bytes(resp.into_body()).await.unwrap().len(),
+        0
+    );
 
     server.abort();
 }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -2225,7 +2225,9 @@ mod tests {
 
     #[tokio::test]
     async fn mempool_file_restored_on_start() {
-        let _ = std::fs::remove_file("mempool.bin");
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
         {
             let mut chain = Blockchain::new();
             chain.add_transaction(coinbase_transaction(A1, 5));
@@ -2249,7 +2251,7 @@ mod tests {
         let (_addrs, _) = node.start().await.unwrap();
         assert_eq!(node.chain.lock().await.mempool_len(), 1);
         assert!(!std::path::Path::new("mempool.bin").exists());
-        let _ = std::fs::remove_file("mempool.bin");
+        std::env::set_current_dir(prev).unwrap();
     }
 
     #[tokio::test]

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -2249,6 +2249,7 @@ mod tests {
         let (_addrs, _) = node.start().await.unwrap();
         assert_eq!(node.chain.lock().await.mempool_len(), 1);
         assert!(!std::path::Path::new("mempool.bin").exists());
+        let _ = std::fs::remove_file("mempool.bin");
     }
 
     #[tokio::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1209,6 +1209,19 @@ mod tests {
     }
 
     #[test]
+    fn merkle_root_empty_slice() {
+        let root = merkle_root_from_hashes(&[]);
+        assert_eq!(root, hex::encode(Sha256::digest(&[])));
+    }
+
+    #[test]
+    fn compute_merkle_single_tx() {
+        let tx = coinbase_transaction(A1, 1);
+        let root = compute_merkle_root(&[tx.clone()]);
+        assert_eq!(root, tx.hash());
+    }
+
+    #[test]
     fn prune_preserves_hash() {
         let bc = Blockchain::new();
         let tx = coinbase_transaction(A1, bc.block_subsidy());


### PR DESCRIPTION
## Summary
- connect HTTP requests to the running node via RPC
- encode the node's replies as JSON for the HTTP responses
- allow configuring the node address for the HTTP server
- test that HTTP endpoints retrieve chain data from a live node

## Testing
- `cargo test --workspace`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: Coverage is below the failure threshold 88.62% < 90.00%)*

------
https://chatgpt.com/codex/tasks/task_e_686450c793bc832ebf18f541631179b5