### PR TITLE
Integrate RocksDB persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,7 +269,18 @@ version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -254,6 +314,17 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -307,6 +378,7 @@ dependencies = [
  "hex",
  "proptest",
  "ripemd",
+ "rocksdb",
  "secp256k1",
  "serde",
  "serde_json",
@@ -722,6 +794,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,6 +1156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,10 +1174,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen 0.65.1",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1114,6 +1245,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1277,12 @@ dependencies = [
  "hex-literal",
  "sha2",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1172,6 +1319,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1294,6 +1451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1523,16 @@ checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1586,6 +1759,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "rpassword"
 version = "7.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1794,18 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -2789,4 +2984,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "bindgen 0.71.1",
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1"
 secp256k1 = { version = "0.27", features = ["recovery"] }
 ripemd = "0.1"
 bincode = "1"
+rocksdb = "0.21"
 contract-runtime = { path = "contract-runtime" }
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coin
 
-This project aims to become a full-fledged coin system built with multiple crates. Network interactions are handled via a JSON-RPC interface exposed by the `coin-p2p` crate. The main `coin` crate provides core blockchain functionality. Unit tests cover all functionality and code coverage is measured using `cargo tarpaulin`.
+This project aims to become a full-fledged coin system built with multiple crates. Network interactions are handled via a JSON-RPC interface exposed by the `coin-p2p` crate. The main `coin` crate provides core blockchain functionality and persists blocks and UTXO data in a RocksDB database. Unit tests cover all functionality and code coverage is measured using `cargo tarpaulin`.
 
 Each coin is divisible into 100&nbsp;000&nbsp;000 units allowing for very small transfers.
 
@@ -79,7 +79,7 @@ Field descriptions:
 - `listeners` – network interfaces and ports to bind.
 - `wallet_address` – optional address used when mining rewards are paid.
 - `node_type` – one of `Miner`, `Wallet`, or `Verifier`.
-- `block_dir` – directory where block files are stored.
+- `block_dir` – directory where the RocksDB database is stored.
 - `seed_peers` – peers contacted on startup for bootstrapping.
 - `mining_threads` – optional number of threads used for mining. When omitted,
   the miner automatically utilizes all available CPU cores. Faster hardware or

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Field descriptions:
 - `listeners` – network interfaces and ports to bind.
 - `wallet_address` – optional address used when mining rewards are paid.
 - `node_type` – one of `Miner`, `Wallet`, or `Verifier`.
-- `block_dir` – directory where the RocksDB database is stored.
+- `block_dir` – directory where RocksDB data is stored. The `blocks` and `utxos`
+  subdirectories hold block data and the UTXO set respectively.
 - `seed_peers` – peers contacted on startup for bootstrapping.
 - `mining_threads` – optional number of threads used for mining. When omitted,
   the miner automatically utilizes all available CPU cores. Faster hardware or

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,7 +6,7 @@ listeners:
 wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 # Node type: Wallet, Miner or Verifier
 node_type: Miner
-# Directory where block files are stored
+# Directory where RocksDB data is stored
 block_dir: "blocks"
 # List of peers to connect to on startup
 seed_peers:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,7 +6,8 @@ listeners:
 wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 # Node type: Wallet, Miner or Verifier
 node_type: Miner
-# Directory where RocksDB data is stored
+# Directory where RocksDB data is stored. Two subdirectories, `blocks` and
+# `utxos`, hold the chain and UTXO database respectively.
 block_dir: "blocks"
 # List of peers to connect to on startup
 seed_peers:

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ listeners:
     port: 9000
 wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 node_type: Miner
-block_dir: "blocks"  # RocksDB storage directory
+block_dir: "blocks"  # RocksDB storage directory (contains `blocks` and `utxos`)
 seed_peers:
   - "127.0.0.1:9001"
 max_msgs_per_sec: 10

--- a/config.yaml
+++ b/config.yaml
@@ -3,7 +3,7 @@ listeners:
     port: 9000
 wallet_address: "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr"
 node_type: Miner
-block_dir: "blocks"
+block_dir: "blocks"  # RocksDB storage directory
 seed_peers:
   - "127.0.0.1:9001"
 max_msgs_per_sec: 10

--- a/contract-runtime/examples/counter.rs
+++ b/contract-runtime/examples/counter.rs
@@ -1,13 +1,14 @@
-extern "C" {
+unsafe extern "C" {
     fn get(key: i32) -> i64;
     fn set(key: i32, value: i64);
 }
 
-#[no_mangle]
-pub extern "C" fn main() -> i64 {
+pub unsafe extern "C" fn contract_main() -> i64 {
     unsafe {
         let v = get(0);
         set(0, v + 1);
         get(0)
     }
 }
+
+fn main() {}

--- a/contract-runtime/examples/simple.rs
+++ b/contract-runtime/examples/simple.rs
@@ -1,4 +1,5 @@
-#[no_mangle]
-pub extern "C" fn main() -> i64 {
+pub unsafe extern "C" fn contract_main() -> i64 {
     42
 }
+
+fn main() {}

--- a/contract-runtime/examples/token.rs
+++ b/contract-runtime/examples/token.rs
@@ -1,4 +1,4 @@
-extern "C" {
+unsafe extern "C" {
     fn get(key: i32) -> i64;
     fn set(key: i32, value: i64);
 }
@@ -68,8 +68,7 @@ unsafe fn write_u256(base: i32, val: U256) {
     write_u128(base + 2, val.hi);
 }
 
-#[no_mangle]
-pub extern "C" fn main() -> i64 {
+pub unsafe extern "C" fn contract_main() -> i64 {
     unsafe {
         let mut total = read_u256(TOTAL_SUPPLY_BASE);
         if total.is_zero() {
@@ -93,3 +92,5 @@ pub extern "C" fn main() -> i64 {
         read_u128(BOB_BASE) as i64
     }
 }
+
+fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -993,6 +993,7 @@ mod tests {
         bc.save(dir.path()).unwrap();
         let db = rocksdb::DB::open_default(dir.path()).unwrap();
         assert_eq!(db.iterator(rocksdb::IteratorMode::Start).count(), 2);
+        drop(db);
         let loaded = Blockchain::load(dir.path()).unwrap();
         assert_eq!(loaded.all(), bc.all());
     }
@@ -1017,6 +1018,7 @@ mod tests {
         bc.save(dir.path()).unwrap();
         let db = rocksdb::DB::open_default(dir.path()).unwrap();
         db.put(999u32.to_be_bytes(), b"junk").unwrap();
+        drop(db);
         bc.save(dir.path()).unwrap();
         let db = rocksdb::DB::open_default(dir.path()).unwrap();
         let count = db.iterator(rocksdb::IteratorMode::Start).count();
@@ -1373,8 +1375,9 @@ mod tests {
         });
         let dir = tempfile::tempdir().unwrap();
         bc.save(dir.path()).unwrap();
-        let db = rocksdb::DB::open_default(dir.path()).unwrap();
+        let db = rocksdb::DB::open_default(dir.path().join("utxos")).unwrap();
         db.delete(b"utxos").unwrap();
+        drop(db);
         let loaded = Blockchain::load(dir.path()).unwrap();
         assert_eq!(loaded.balance(&addr1), bc.balance(&addr1));
         assert_eq!(loaded.balance(&addr2), bc.balance(&addr2));

--- a/src/utxofile.rs
+++ b/src/utxofile.rs
@@ -16,16 +16,18 @@ fn serialize_error<E: std::fmt::Display>(e: E) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, format!("serialize error: {e}"))
 }
 
-pub fn save_utxos<P: AsRef<Path>>(path: P, utxos: &HashMap<String, u64>) -> std::io::Result<()> {
-    let db = open_db(path.as_ref())?;
+pub fn save_utxos<P: AsRef<Path>>(base: P, utxos: &HashMap<String, u64>) -> std::io::Result<()> {
+    let db_path = base.as_ref().join("utxos");
+    let db = open_db(&db_path)?;
     let data = bincode::serialize(utxos).map_err(serialize_error)?;
     db.put(UTXO_KEY, data)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
     Ok(())
 }
 
-pub fn load_utxos<P: AsRef<Path>>(path: P) -> std::io::Result<HashMap<String, u64>> {
-    let db = open_db(path.as_ref())?;
+pub fn load_utxos<P: AsRef<Path>>(base: P) -> std::io::Result<HashMap<String, u64>> {
+    let db_path = base.as_ref().join("utxos");
+    let db = open_db(&db_path)?;
     match db.get(UTXO_KEY) {
         Ok(Some(val)) => bincode::deserialize(&val)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
@@ -49,14 +51,14 @@ mod tests {
         save_utxos(dir.path(), &map).unwrap();
         let loaded = load_utxos(dir.path()).unwrap();
         assert_eq!(loaded, map);
-        let db = open_db(dir.path()).unwrap();
+        let db = open_db(&dir.path().join("utxos")).unwrap();
         assert_eq!(db.iterator(IteratorMode::Start).count(), 1);
     }
 
     #[test]
     fn invalid_data() {
         let dir = tempdir().unwrap();
-        let db = open_db(dir.path()).unwrap();
+        let db = open_db(&dir.path().join("utxos")).unwrap();
         db.put(UTXO_KEY, [0u8, 1u8]).unwrap();
         let res = load_utxos(dir.path());
         assert!(res.is_err());


### PR DESCRIPTION
## Summary
- switch block and UTXO storage to RocksDB
- migrate existing blk files into the new database on demand
- update examples for Rust 2024 edition
- document new RocksDB usage and update configs

## Testing
- `cargo test --workspace` *(fails: build takes too long and examples emit warnings)*
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(command unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68649cfc7738832ebd3095ffbd805c2c