### PR TITLE
Implement consensus finalization and slashing

### DIFF
--- a/contract-runtime/examples/counter.rs
+++ b/contract-runtime/examples/counter.rs
@@ -1,13 +1,11 @@
-extern "C" {
+unsafe extern "C" {
     fn get(key: i32) -> i64;
     fn set(key: i32, value: i64);
 }
 
 #[no_mangle]
-pub extern "C" fn main() -> i64 {
-    unsafe {
-        let v = get(0);
-        set(0, v + 1);
-        get(0)
-    }
+pub unsafe extern "C" fn main() -> i64 {
+    let v = get(0);
+    set(0, v + 1);
+    get(0)
 }

--- a/p2p/src/rpc.rs
+++ b/p2p/src/rpc.rs
@@ -1,6 +1,7 @@
 use coin_proto::{
-    Balance, Block, Chain, GetBalance, GetBlock, GetBlocks, GetChain, GetPeers, GetTransaction,
-    Handshake, Peers, Ping, Pong, Schedule, Stake, Transaction, TransactionDetail, Unstake, Vote,
+    Balance, Block, Chain, Finalize, GetBalance, GetBlock, GetBlocks, GetChain, GetPeers,
+    GetTransaction, Handshake, Peers, Ping, Pong, Schedule, Stake, Transaction, TransactionDetail,
+    Unstake, Vote,
 };
 use jsonrpc_lite::JsonRpc;
 use serde_json::{Value, json};
@@ -27,6 +28,7 @@ pub enum RpcMessage {
     Unstake(Unstake),
     Vote(Vote),
     Schedule(Schedule),
+    Finalize(Finalize),
     Handshake(Handshake),
 }
 
@@ -54,6 +56,7 @@ pub fn encode_message(msg: &RpcMessage) -> JsonRpc {
         RpcMessage::Unstake(u) => JsonRpc::notification_with_params("unstake", json!(u)),
         RpcMessage::Vote(v) => JsonRpc::notification_with_params("vote", json!(v)),
         RpcMessage::Schedule(s) => JsonRpc::notification_with_params("schedule", json!(s)),
+        RpcMessage::Finalize(f) => JsonRpc::notification_with_params("finalize", json!(f)),
         RpcMessage::Handshake(h) => JsonRpc::notification_with_params("handshake", json!(h)),
     }
 }
@@ -120,6 +123,10 @@ pub fn decode_message(rpc: JsonRpc) -> Option<RpcMessage> {
             .get_params()
             .and_then(|p| serde_json::from_value::<Schedule>(params_to_value(p)).ok())
             .map(RpcMessage::Schedule),
+        "finalize" => rpc
+            .get_params()
+            .and_then(|p| serde_json::from_value::<Finalize>(params_to_value(p)).ok())
+            .map(RpcMessage::Finalize),
         "handshake" => rpc
             .get_params()
             .and_then(|p| serde_json::from_value::<Handshake>(params_to_value(p)).ok())

--- a/p2p/tests/consensus.rs
+++ b/p2p/tests/consensus.rs
@@ -114,5 +114,6 @@ async fn finalize_block_on_votes() {
     drop(cs);
     let saved = Blockchain::load(dir.path()).unwrap_or_else(|e| panic!("{:?}", e));
     assert_eq!(saved.len(), 2);
+    assert!(saved.is_finalized(&hash));
     node.shutdown();
 }

--- a/p2p/tests/network.rs
+++ b/p2p/tests/network.rs
@@ -176,6 +176,11 @@ async fn network_votes_finalize_block() {
             let cs = cs.lock().await;
             assert!(cs.is_finalized(&hash));
         }
+        {
+            let chain = node_a.chain_handle();
+            let chain = chain.lock().await;
+            assert!(chain.is_finalized(&hash));
+        }
 
         node_a.shutdown();
         node_b.shutdown();

--- a/p2p/tests/rpc.rs
+++ b/p2p/tests/rpc.rs
@@ -1,6 +1,7 @@
 use coin_p2p::rpc::{RpcMessage, decode_message, encode_message, read_rpc, write_rpc};
 use coin_proto::{
-    Balance, GetBalance, GetBlocks, GetTransaction, Schedule, Transaction, TransactionDetail, Vote,
+    Balance, Finalize, GetBalance, GetBlocks, GetTransaction, Schedule, Transaction,
+    TransactionDetail, Vote,
 };
 use jsonrpc_lite::JsonRpc;
 use serde_json;
@@ -31,6 +32,14 @@ fn vote_and_schedule_roundtrip() {
     let dec2 = decode_message(json2).unwrap();
     match dec2 {
         RpcMessage::Schedule(s2) => assert_eq!(s2, sched),
+        _ => panic!("wrong message"),
+    }
+
+    let final_msg = RpcMessage::Finalize(Finalize { hash: "abc".into() });
+    let enc = encode_message(&final_msg);
+    let decf = decode_message(enc).unwrap();
+    match decf {
+        RpcMessage::Finalize(f) => assert_eq!(f.hash, "abc"),
         _ => panic!("wrong message"),
     }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -126,6 +126,11 @@ pub struct Schedule {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Finalize {
+    pub hash: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Stake {
     pub address: String,
     pub amount: u64,
@@ -204,6 +209,14 @@ mod tests {
         let data = serde_json::to_vec(&sched).unwrap();
         let decoded: Schedule = serde_json::from_slice(&data).unwrap();
         assert_eq!(sched, decoded);
+    }
+
+    #[test]
+    fn finalize_roundtrip() {
+        let fin = Finalize { hash: "h".into() };
+        let data = serde_json::to_vec(&fin).unwrap();
+        let decoded: Finalize = serde_json::from_slice(&data).unwrap();
+        assert_eq!(fin, decoded);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Finalize message to protocol
- track finalized blocks in `Blockchain`
- implement validator unbonding and slashing in staking
- broadcast finalized hashes between nodes
- test consensus updates

## Testing
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: "Test failed during run")*

------
https://chatgpt.com/codex/tasks/task_e_6864a19cc554832e94266f3aaaded188