### PR TITLE
Add storage helpers for large values

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ rustc --target wasm32-unknown-unknown -O contract-runtime/examples/counter.rs -o
 
 - `simple.rs` returns `42` from its `main` function.
 - `counter.rs` increments an internal counter stored under key `0` via the host
-  `get` and `set` functions.
+  `get` and `set` functions. The runtime also exposes helpers for boolean,
+  128-bit, 256-bit and address values through `get_bool`/`set_bool`,
+  `get_u128`/`set_u128`, `get_u256`/`set_u256` and
+  `get_address`/`set_address`.
 - `token.rs` demonstrates 256-bit arithmetic by minting
   `100,000,000,000,000,000,000,000,000` tokens to Alice on first run. Balances
   are stored across four 64-bit slots per account and one token is transferred

--- a/contract-runtime/src/lib.rs
+++ b/contract-runtime/src/lib.rs
@@ -82,6 +82,96 @@ impl Runtime {
                 caller.data_mut().insert(key, val);
             },
         )?;
+        linker.func_wrap(
+            "env",
+            "get_bool",
+            |caller: Caller<'_, HashMap<i32, i64>>, key: i32| {
+                if *caller.data().get(&key).unwrap_or(&0) != 0 {
+                    1i32
+                } else {
+                    0i32
+                }
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "set_bool",
+            |mut caller: Caller<'_, HashMap<i32, i64>>, key: i32, val: i32| {
+                caller.data_mut().insert(key, if val == 0 { 0 } else { 1 });
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "get_u128",
+            |caller: Caller<'_, HashMap<i32, i64>>, base: i32| {
+                (
+                    *caller.data().get(&base).unwrap_or(&0),
+                    *caller.data().get(&(base + 1)).unwrap_or(&0),
+                )
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "set_u128",
+            |mut caller: Caller<'_, HashMap<i32, i64>>, base: i32, lo: i64, hi: i64| {
+                caller.data_mut().insert(base, lo);
+                caller.data_mut().insert(base + 1, hi);
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "get_u256",
+            |caller: Caller<'_, HashMap<i32, i64>>, base: i32| {
+                (
+                    *caller.data().get(&base).unwrap_or(&0),
+                    *caller.data().get(&(base + 1)).unwrap_or(&0),
+                    *caller.data().get(&(base + 2)).unwrap_or(&0),
+                    *caller.data().get(&(base + 3)).unwrap_or(&0),
+                )
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "set_u256",
+            |mut caller: Caller<'_, HashMap<i32, i64>>,
+             base: i32,
+             a: i64,
+             b: i64,
+             c: i64,
+             d: i64| {
+                caller.data_mut().insert(base, a);
+                caller.data_mut().insert(base + 1, b);
+                caller.data_mut().insert(base + 2, c);
+                caller.data_mut().insert(base + 3, d);
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "get_address",
+            |caller: Caller<'_, HashMap<i32, i64>>, base: i32| {
+                (
+                    *caller.data().get(&base).unwrap_or(&0),
+                    *caller.data().get(&(base + 1)).unwrap_or(&0),
+                    *caller.data().get(&(base + 2)).unwrap_or(&0),
+                    *caller.data().get(&(base + 3)).unwrap_or(&0),
+                )
+            },
+        )?;
+        linker.func_wrap(
+            "env",
+            "set_address",
+            |mut caller: Caller<'_, HashMap<i32, i64>>,
+             base: i32,
+             a: i64,
+             b: i64,
+             c: i64,
+             d: i64| {
+                caller.data_mut().insert(base, a);
+                caller.data_mut().insert(base + 1, b);
+                caller.data_mut().insert(base + 2, c);
+                caller.data_mut().insert(base + 3, d);
+            },
+        )?;
         let instance = linker.instantiate(&mut store, module)?.start(&mut store)?;
         let func = instance.get_typed_func::<(), i64>(&store, "main")?;
         let result = match func.call(&mut store, ()) {

--- a/contract-runtime/tests/runtime.rs
+++ b/contract-runtime/tests/runtime.rs
@@ -119,3 +119,166 @@ fn gas_consumption() {
     assert!(rt.execute("dave", &mut gas).is_ok());
     assert!(gas < 10);
 }
+
+#[test]
+#[serial]
+fn bool_storage() {
+    let wat = r#"
+    (module
+        (import "env" "get_bool" (func $get (param i32) (result i32)))
+        (import "env" "set_bool" (func $set (param i32 i32)))
+        (func (export "main") (result i64)
+            (local $v i32)
+            (local.set $v (call $get (i32.const 0)))
+            (call $set (i32.const 0) (i32.eqz (local.get $v)))
+            (i64.extend_i32_u (call $get (i32.const 0)))
+        )
+    )
+    "#;
+    let wasm = wat::parse_str(wat).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
+    }
+    let mut rt = Runtime::new();
+    rt.deploy("bob", &wasm).unwrap();
+    let mut gas = 10_000;
+    assert_eq!(rt.execute("bob", &mut gas).unwrap(), 1);
+    let mut gas2 = 10_000;
+    assert_eq!(rt.execute("bob", &mut gas2).unwrap(), 0);
+    unsafe {
+        std::env::remove_var("CONTRACT_STATE_FILE");
+    }
+}
+
+#[test]
+#[serial]
+fn u128_storage() {
+    let wat = r#"
+    (module
+        (import "env" "get_u128" (func $get (param i32) (result i64 i64)))
+        (import "env" "set_u128" (func $set (param i32 i64 i64)))
+        (func (export "main") (result i64)
+            (local $lo i64)
+            (local $hi i64)
+            (call $get (i32.const 0))
+            (local.set $hi)
+            (local.set $lo)
+            (if (i64.eq (local.get $lo) (i64.const 0))
+                (then (call $set (i32.const 0) (i64.const 1) (i64.const 0)))
+                (else (call $set (i32.const 0) (i64.const 2) (i64.const 0)))
+            )
+            (call $get (i32.const 0))
+            (local.set $hi)
+            (local.set $lo)
+            (local.get $lo)
+        )
+    )
+    "#;
+    let wasm = wat::parse_str(wat).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
+    }
+    let mut rt = Runtime::new();
+    rt.deploy("eve", &wasm).unwrap();
+    let mut gas = 10_000;
+    assert_eq!(rt.execute("eve", &mut gas).unwrap(), 1);
+    let mut gas2 = 10_000;
+    assert_eq!(rt.execute("eve", &mut gas2).unwrap(), 2);
+    unsafe {
+        std::env::remove_var("CONTRACT_STATE_FILE");
+    }
+}
+
+#[test]
+#[serial]
+fn u256_storage() {
+    let wat = r#"
+    (module
+        (import "env" "get_u256" (func $get (param i32) (result i64 i64 i64 i64)))
+        (import "env" "set_u256" (func $set (param i32 i64 i64 i64 i64)))
+        (func (export "main") (result i64)
+            (local $a i64)
+            (local $b i64)
+            (local $c i64)
+            (local $d i64)
+            (call $get (i32.const 0))
+            (local.set $d)
+            (local.set $c)
+            (local.set $b)
+            (local.set $a)
+            (if (i64.eq (local.get $a) (i64.const 0))
+                (then (call $set (i32.const 0) (i64.const 1) (i64.const 0) (i64.const 0) (i64.const 0)))
+                (else (call $set (i32.const 0) (i64.const 2) (i64.const 0) (i64.const 0) (i64.const 0)))
+            )
+            (call $get (i32.const 0))
+            (local.set $d)
+            (local.set $c)
+            (local.set $b)
+            (local.set $a)
+            (local.get $a)
+        )
+    )
+    "#;
+    let wasm = wat::parse_str(wat).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
+    }
+    let mut rt = Runtime::new();
+    rt.deploy("frank", &wasm).unwrap();
+    let mut gas = 10_000;
+    assert_eq!(rt.execute("frank", &mut gas).unwrap(), 1);
+    let mut gas2 = 10_000;
+    assert_eq!(rt.execute("frank", &mut gas2).unwrap(), 2);
+    unsafe {
+        std::env::remove_var("CONTRACT_STATE_FILE");
+    }
+}
+
+#[test]
+#[serial]
+fn address_storage() {
+    let wat = r#"
+    (module
+        (import "env" "get_address" (func $get (param i32) (result i64 i64 i64 i64)))
+        (import "env" "set_address" (func $set (param i32 i64 i64 i64 i64)))
+        (func (export "main") (result i64)
+            (local $a i64)
+            (local $b i64)
+            (local $c i64)
+            (local $d i64)
+            (call $get (i32.const 0))
+            (local.set $d)
+            (local.set $c)
+            (local.set $b)
+            (local.set $a)
+            (if (i64.eq (local.get $a) (i64.const 0))
+                (then (call $set (i32.const 0) (i64.const 11) (i64.const 22) (i64.const 33) (i64.const 44)))
+                (else (call $set (i32.const 0) (i64.const 55) (i64.const 66) (i64.const 77) (i64.const 88)))
+            )
+            (call $get (i32.const 0))
+            (local.set $d)
+            (local.set $c)
+            (local.set $b)
+            (local.set $a)
+            (local.get $a)
+        )
+    )
+    "#;
+    let wasm = wat::parse_str(wat).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    unsafe {
+        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
+    }
+    let mut rt = Runtime::new();
+    rt.deploy("gina", &wasm).unwrap();
+    let mut gas = 10_000;
+    assert_eq!(rt.execute("gina", &mut gas).unwrap(), 11);
+    let mut gas2 = 10_000;
+    assert_eq!(rt.execute("gina", &mut gas2).unwrap(), 55);
+    unsafe {
+        std::env::remove_var("CONTRACT_STATE_FILE");
+    }
+}


### PR DESCRIPTION
## Summary
- support `get_u128`/`set_u128` and `get_u256`/`set_u256` for contract runtime
- document available storage helpers in the README

## Testing
- `cargo test`
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90`


------
https://chatgpt.com/codex/tasks/task_e_686530e03018832ebe2b952aa3278309