### PR TITLE
Fix env var usage in tests

### DIFF
--- a/contract-runtime/tests/runtime.rs
+++ b/contract-runtime/tests/runtime.rs
@@ -55,6 +55,7 @@ fn state_persistence() {
     assert!(gas < 10_000);
     let mut gas2 = 10_000;
     assert_eq!(rt.execute("alice", &mut gas2).unwrap(), 2);
+    // drop env var to avoid side effects between tests
     std::env::remove_var("CONTRACT_STATE_FILE");
 }
 

--- a/contract-runtime/tests/runtime.rs
+++ b/contract-runtime/tests/runtime.rs
@@ -47,9 +47,7 @@ fn state_persistence() {
     "#;
     let wasm = wat::parse_str(wat).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
-    }
+    std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
     let mut rt = Runtime::new();
     rt.deploy("alice", &wasm).unwrap();
     let mut gas = 10_000;
@@ -57,9 +55,7 @@ fn state_persistence() {
     assert!(gas < 10_000);
     let mut gas2 = 10_000;
     assert_eq!(rt.execute("alice", &mut gas2).unwrap(), 2);
-    unsafe {
-        std::env::remove_var("CONTRACT_STATE_FILE");
-    }
+    std::env::remove_var("CONTRACT_STATE_FILE");
 }
 
 #[test]
@@ -79,9 +75,7 @@ fn state_reload_from_disk() {
     "#;
     let wasm = wat::parse_str(wat).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
-    }
+    std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
     {
         let mut rt = Runtime::new();
         rt.deploy("alice", &wasm).unwrap();
@@ -94,9 +88,7 @@ fn state_reload_from_disk() {
         let mut gas = 10_000;
         assert_eq!(rt.execute("alice", &mut gas).unwrap(), 2);
     }
-    unsafe {
-        std::env::remove_var("CONTRACT_STATE_FILE");
-    }
+    std::env::remove_var("CONTRACT_STATE_FILE");
 }
 #[test]
 fn out_of_gas() {
@@ -137,18 +129,14 @@ fn bool_storage() {
     "#;
     let wasm = wat::parse_str(wat).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
-    }
+    std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
     let mut rt = Runtime::new();
     rt.deploy("bob", &wasm).unwrap();
     let mut gas = 10_000;
     assert_eq!(rt.execute("bob", &mut gas).unwrap(), 1);
     let mut gas2 = 10_000;
     assert_eq!(rt.execute("bob", &mut gas2).unwrap(), 0);
-    unsafe {
-        std::env::remove_var("CONTRACT_STATE_FILE");
-    }
+    std::env::remove_var("CONTRACT_STATE_FILE");
 }
 
 #[test]
@@ -177,18 +165,14 @@ fn u128_storage() {
     "#;
     let wasm = wat::parse_str(wat).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
-    }
+    std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
     let mut rt = Runtime::new();
     rt.deploy("eve", &wasm).unwrap();
     let mut gas = 10_000;
     assert_eq!(rt.execute("eve", &mut gas).unwrap(), 1);
     let mut gas2 = 10_000;
     assert_eq!(rt.execute("eve", &mut gas2).unwrap(), 2);
-    unsafe {
-        std::env::remove_var("CONTRACT_STATE_FILE");
-    }
+    std::env::remove_var("CONTRACT_STATE_FILE");
 }
 
 #[test]
@@ -223,18 +207,14 @@ fn u256_storage() {
     "#;
     let wasm = wat::parse_str(wat).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
-    }
+    std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
     let mut rt = Runtime::new();
     rt.deploy("frank", &wasm).unwrap();
     let mut gas = 10_000;
     assert_eq!(rt.execute("frank", &mut gas).unwrap(), 1);
     let mut gas2 = 10_000;
     assert_eq!(rt.execute("frank", &mut gas2).unwrap(), 2);
-    unsafe {
-        std::env::remove_var("CONTRACT_STATE_FILE");
-    }
+    std::env::remove_var("CONTRACT_STATE_FILE");
 }
 
 #[test]
@@ -269,16 +249,12 @@ fn address_storage() {
     "#;
     let wasm = wat::parse_str(wat).unwrap();
     let dir = tempfile::tempdir().unwrap();
-    unsafe {
-        std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
-    }
+    std::env::set_var("CONTRACT_STATE_FILE", dir.path().join("state.json"));
     let mut rt = Runtime::new();
     rt.deploy("gina", &wasm).unwrap();
     let mut gas = 10_000;
     assert_eq!(rt.execute("gina", &mut gas).unwrap(), 11);
     let mut gas2 = 10_000;
     assert_eq!(rt.execute("gina", &mut gas2).unwrap(), 55);
-    unsafe {
-        std::env::remove_var("CONTRACT_STATE_FILE");
-    }
+    std::env::remove_var("CONTRACT_STATE_FILE");
 }

--- a/p2p/tests/consensus.rs
+++ b/p2p/tests/consensus.rs
@@ -19,9 +19,7 @@ fn sign_vote(path: &str, vote: &mut Vote) {
 #[tokio::test]
 async fn finalize_block_on_votes() {
     let dir = tempdir().unwrap();
-    unsafe {
-        std::env::set_var("BLOCK_DIR", dir.path());
-    }
+    std::env::set_var("BLOCK_DIR", dir.path());
     let node = Node::with_interval(
         vec!["0.0.0.0:0".parse().unwrap()],
         Duration::from_millis(50),

--- a/p2p/tests/consensus.rs
+++ b/p2p/tests/consensus.rs
@@ -114,5 +114,6 @@ async fn finalize_block_on_votes() {
     let saved = Blockchain::load(dir.path()).unwrap_or_else(|e| panic!("{:?}", e));
     assert_eq!(saved.len(), 2);
     node.shutdown();
+    // clean up so other tests pick their own directories
     std::env::remove_var("BLOCK_DIR");
 }

--- a/p2p/tests/consensus.rs
+++ b/p2p/tests/consensus.rs
@@ -114,4 +114,5 @@ async fn finalize_block_on_votes() {
     let saved = Blockchain::load(dir.path()).unwrap_or_else(|e| panic!("{:?}", e));
     assert_eq!(saved.len(), 2);
     node.shutdown();
+    std::env::remove_var("BLOCK_DIR");
 }

--- a/p2p/tests/persistence.rs
+++ b/p2p/tests/persistence.rs
@@ -64,4 +64,5 @@ async fn reloads_block_after_restart() {
     assert_eq!(block_hash, loaded_hash);
     node2.save_peers().await.unwrap();
     node2.shutdown();
+    std::env::remove_var("BLOCK_DIR");
 }

--- a/p2p/tests/persistence.rs
+++ b/p2p/tests/persistence.rs
@@ -64,5 +64,6 @@ async fn reloads_block_after_restart() {
     assert_eq!(block_hash, loaded_hash);
     node2.save_peers().await.unwrap();
     node2.shutdown();
+    // remove env var so later tests have a fresh state
     std::env::remove_var("BLOCK_DIR");
 }

--- a/p2p/tests/persistence.rs
+++ b/p2p/tests/persistence.rs
@@ -8,9 +8,7 @@ const MINER: &str = "1BvgsfsZQVtkLS69NvGF8rw6NZW2ShJQHr";
 #[tokio::test]
 async fn reloads_block_after_restart() {
     let dir = tempdir().unwrap();
-    unsafe {
-        std::env::set_var("BLOCK_DIR", dir.path());
-    }
+    std::env::set_var("BLOCK_DIR", dir.path());
 
     let node1 = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],

--- a/src/blockfile.rs
+++ b/src/blockfile.rs
@@ -21,7 +21,7 @@ fn open_db(path: &Path, create: bool) -> std::io::Result<DB> {
     DB::open(&opts, path).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
 }
 
-fn db_exists(path: &Path) -> bool {
+pub(crate) fn db_exists(path: &Path) -> bool {
     path.join("CURRENT").exists()
 }
 


### PR DESCRIPTION
## Summary
- remove unnecessary unsafe blocks around environment variable manipulation in tests
- make `db_exists` visible within the crate

## Testing
- `cargo test --no-run`

------
https://chatgpt.com/codex/tasks/task_e_686706afb004832ebd5089885e60a001