### PR TITLE
Update AGENT instructions for testing clarity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
 # Contributor Guidelines
 
 - Always run `cargo fmt` and `cargo test` before committing.
+- Verify that `cargo test` completes successfully and fix any failing tests before concluding your work.
 - For coverage checks, run `cargo tarpaulin --workspace --timeout 60 --fail-under 90`.
+- Double check that the coverage command completes successfully and the coverage percentage stays above 90%.
 - Include unit tests for all new functionality. Overall test coverage must stay above 90%, and PRs should strive to push coverage toward the 95% target.
 - Use defensive programming and clear code structure.
 - Organize functionality into separate crates whenever it makes sense.

--- a/src/blockfile.rs
+++ b/src/blockfile.rs
@@ -21,7 +21,7 @@ fn open_db(path: &Path, create: bool) -> std::io::Result<DB> {
     DB::open(&opts, path).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
 }
 
-fn db_exists(path: &Path) -> bool {
+pub fn db_exists(path: &Path) -> bool {
     path.join("CURRENT").exists()
 }
 


### PR DESCRIPTION
## Summary
- clarify instructions to run tests and check coverage
- expose `db_exists` for use in other modules

## Testing
- `cargo fmt`
- `cargo test -- --test-threads=1` *(fails: lock hold by current process)*
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: Test failed during run)*

------
https://chatgpt.com/codex/tasks/task_e_686728f349d0832ea71bcdd8de463c1f