### PR TITLE
Make Runtime state file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ let wat = "(module (func (export \"main\") (result i32) i32.const 42))";
 let wasm = wat::parse_str(wat).unwrap();
 
 // Deploy and run a contract
-let mut rt = Runtime::new();
+let mut rt = Runtime::new(None);
 rt.deploy("alice", &wasm).unwrap();
 let mut gas = 1_000_000;
 let result = rt.execute("alice", &mut gas).unwrap();


### PR DESCRIPTION
## Summary
- allow specifying a state file path when creating a `Runtime`
- store the path inside `Runtime` and persist state using it
- update examples and tests to supply a path

## Testing
- `cargo test` *(fails: lock hold by current process)*
- `cargo test -- --test-threads=1` *(fails: lock hold by current process)*
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(failed to complete)*

------
https://chatgpt.com/codex/tasks/task_e_6867f8b633c0832ea9786bc8a0724596