### PR TITLE
Improve stake error handling

### DIFF
--- a/p2p/tests/consensus.rs
+++ b/p2p/tests/consensus.rs
@@ -74,8 +74,8 @@ async fn finalize_block_on_votes() {
         let chain_handle = node.chain_handle();
         let mut cs = consensus_handle.lock().await;
         let mut chain = chain_handle.lock().await;
-        cs.registry_mut().stake(&mut chain, A1, 30);
-        cs.registry_mut().stake(&mut chain, A2, 30);
+        cs.registry_mut().stake(&mut chain, A1, 30).unwrap();
+        cs.registry_mut().stake(&mut chain, A2, 30).unwrap();
         cs.registry_mut().advance_round(&mut chain);
         cs.start_round(hash.clone(), &mut chain);
     }

--- a/p2p/tests/network.rs
+++ b/p2p/tests/network.rs
@@ -154,8 +154,8 @@ async fn network_votes_finalize_block() {
             let chain_handle = node_a.chain_handle();
             let mut cs = consensus_handle.lock().await;
             let mut chain = chain_handle.lock().await;
-            cs.registry_mut().stake(&mut chain, A1, 30);
-            cs.registry_mut().stake(&mut chain, A2, 30);
+            cs.registry_mut().stake(&mut chain, A1, 30).unwrap();
+            cs.registry_mut().stake(&mut chain, A2, 30).unwrap();
             cs.registry_mut().advance_round(&mut chain);
             cs.start_round(hash.clone(), &mut chain);
         }


### PR DESCRIPTION
## Summary
- add `StakeError` enum for staking errors
- return `Result` from `StakeRegistry::stake`
- update tests for new error handling

## Testing
- `cargo test -p stake -- --test-threads=1` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_686887b2e37c832e8fbe053ef1d9b8cd