### PR TITLE
Introduce RpcTransport trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +418,7 @@ name = "coin-p2p"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bincode",
  "clap",
  "coin",

--- a/http-api/tests/http_api.rs
+++ b/http-api/tests/http_api.rs
@@ -179,7 +179,7 @@ async fn test_rpc_error() {
 
 #[tokio::test]
 async fn test_forward_rpc_timeout() {
-    use coin_p2p::rpc::{RpcMessage, read_rpc, write_rpc};
+    use coin_p2p::rpc::{RpcMessage, RpcTransport};
     use coin_proto::Handshake;
     use tokio::net::TcpListener;
     use tokio::time::{Duration, sleep};
@@ -188,14 +188,14 @@ async fn test_forward_rpc_timeout() {
     let addr = listener.local_addr().unwrap();
     let server = tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.unwrap();
-        let _ = read_rpc(&mut stream).await.unwrap();
+        let _ = stream.read_rpc().await.unwrap();
         let reply = RpcMessage::Handshake(Handshake {
             network_id: "coin".into(),
             version: 1,
             public_key: vec![],
             signature: vec![],
         });
-        write_rpc(&mut stream, &reply).await.unwrap();
+        stream.write_rpc(&reply).await.unwrap();
         sleep(Duration::from_secs(2)).await;
     });
 

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -21,6 +21,7 @@ tokio-socks = "0.5"
 bincode = "1"
 jsonrpc-lite = "0.6.1"
 stake = { path = "../stake" }
+async-trait = "0.1"
 
 [dev-dependencies]
 coin-wallet = { path = "../wallet" }

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1,4 +1,4 @@
-use crate::rpc::{RpcMessage, read_rpc, write_rpc};
+use crate::rpc::{RpcMessage, RpcTransport};
 use clap::ValueEnum;
 use coin::meets_difficulty;
 use coin::{Block, BlockHeader, Blockchain, TransactionExt, compute_merkle_root};
@@ -35,12 +35,12 @@ const MAX_TIME_DRIFT_MS: i64 = 2 * 60 * 60 * 1000; // 2 hours
 
 /// Send a length-prefixed JSON-RPC message over the socket
 async fn write_msg(socket: &mut TcpStream, msg: &RpcMessage) -> tokio::io::Result<()> {
-    write_rpc(socket, msg).await
+    socket.write_rpc(msg).await
 }
 
 /// Read a length-prefixed JSON-RPC message from the socket
 async fn read_msg(socket: &mut TcpStream) -> tokio::io::Result<RpcMessage> {
-    read_rpc(socket).await
+    socket.read_rpc().await
 }
 
 async fn read_with_timeout(socket: &mut TcpStream) -> tokio::io::Result<bool> {

--- a/wallet/src/bin/cli.rs
+++ b/wallet/src/bin/cli.rs
@@ -8,7 +8,7 @@ mod real_cli {
     use anyhow::{Result, anyhow};
     use clap::{Parser, Subcommand};
     use coin::{Blockchain, TransactionExt, new_transaction_with_fee};
-    use coin_p2p::rpc::{RpcMessage, read_rpc, write_rpc};
+    use coin_p2p::rpc::{RpcMessage, RpcTransport};
     use coin_proto::{
         Chain, GetChain, Handshake, Stake as RpcStake, Transaction, Unstake as RpcUnstake,
     };
@@ -158,11 +158,11 @@ mod real_cli {
     }
 
     async fn write_msg(stream: &mut TcpStream, msg: &RpcMessage) -> Result<()> {
-        write_rpc(stream, msg).await.map_err(Into::into)
+        stream.write_rpc(msg).await.map_err(Into::into)
     }
 
     async fn read_msg(stream: &mut TcpStream) -> Result<RpcMessage> {
-        read_rpc(stream).await.map_err(Into::into)
+        stream.read_rpc().await.map_err(Into::into)
     }
 
     async fn rpc_connect(addr: &str) -> Result<TcpStream> {


### PR DESCRIPTION
## Summary
- define `RpcTransport` trait with async read/write methods
- implement trait for any async read/write type and create a mock transport
- refactor P2P and HTTP code to use the trait
- update CLI and tests for the new transport abstraction

## Testing
- `cargo test -p coin-http --tests` *(fails: could not finish building dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868a119c0d0832e890113ec3580601e