### PR TITLE
Add extra unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -745,6 +745,24 @@ mod tests {
     }
 
     #[test]
+    fn multi_output_transaction_invalid_address() {
+        // Use a valid sender address but invalid output address to exercise the
+        // error path in new_multi_transaction_with_fee.
+        let sk = secp256k1::SecretKey::from_slice(&[1u8; 32]).unwrap();
+        let sender = address_from_secret(&sk);
+        let result = new_multi_transaction_with_fee(&sender, vec![("badaddr".to_string(), 2)], 1);
+        assert!(matches!(result, Err(Error::InvalidAddress)));
+    }
+
+    #[test]
+    fn merkle_root_invalid_hex_treated_as_empty() {
+        let root = merkle_root_from_hashes(&["zz".to_string()]);
+        // Invalid hex strings are treated as empty byte slices, so the root
+        // should equal the hash of an empty slice.
+        assert_eq!(root, hex::encode(sha2::Sha256::digest(&[])));
+    }
+
+    #[test]
     fn prune_removes_old_transactions() {
         let mut bc = Blockchain::new();
         for i in 0..3 {


### PR DESCRIPTION
## Summary
- add a failing case for `new_multi_transaction_with_fee`
- check merkle root calculation with invalid hex input

## Testing
- `cargo fmt`
- `cargo test` *(fails: process interrupted due to long compile time)*
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868aa88d7d4832e929f6de172182939