### PR TITLE
Introduce NodeConfig struct for Node creation

### DIFF
--- a/http-api/tests/http_api.rs
+++ b/http-api/tests/http_api.rs
@@ -1,5 +1,5 @@
 use coin::{Block, BlockHeader, coinbase_transaction};
-use coin_p2p::{Node, NodeType};
+use coin_p2p::{Node, NodeConfig, NodeType};
 use coin_proto::Transaction;
 use hyper::{Body, Method, Request, StatusCode};
 use reqwest::Client;
@@ -11,16 +11,7 @@ async fn test_http_endpoints() {
     let node = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],
         NodeType::Wallet,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
+        NodeConfig::default(),
     );
     let reward;
     {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -1557,16 +1557,11 @@ mod tests {
             vec!["0.0.0.0:0".parse().unwrap()],
             Duration::from_millis(50),
             NodeType::Miner,
-            Some(0),
-            Some(A1.to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            NodeConfig {
+                min_peers: Some(0),
+                wallet_address: Some(A1.to_string()),
+                ..Default::default()
+            },
         );
         let (_addrs, _rx) = miner.start().await.unwrap();
         sleep(Duration::from_millis(200)).await;
@@ -1579,16 +1574,11 @@ mod tests {
             vec!["0.0.0.0:0".parse().unwrap()],
             Duration::from_millis(50),
             NodeType::Miner,
-            Some(0),
-            Some(A1.to_string()),
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            NodeConfig {
+                min_peers: Some(0),
+                wallet_address: Some(A1.to_string()),
+                ..Default::default()
+            },
         );
         let (_addrs, _rx) = node.start().await.unwrap();
         {

--- a/p2p/src/main.rs
+++ b/p2p/src/main.rs
@@ -26,16 +26,17 @@ async fn main() -> Result<()> {
     let node = Node::new(
         cfg.listener_addrs(),
         cfg.node_type,
-        None,
-        cfg.wallet_address.clone(),
-        None,
-        tor_proxy,
-        Some(cfg.network_id.clone()),
-        Some(cfg.protocol_version),
-        Some(cfg.max_msgs_per_sec),
-        Some(cfg.max_peers),
-        cfg.mining_threads,
-        Some(cfg.block_dir.clone()),
+        NodeConfig {
+            wallet_address: cfg.wallet_address.clone(),
+            tor_proxy,
+            network_id: Some(cfg.network_id.clone()),
+            protocol_version: Some(cfg.protocol_version),
+            max_msgs_per_sec: Some(cfg.max_msgs_per_sec),
+            max_peers: Some(cfg.max_peers),
+            mining_threads: cfg.mining_threads,
+            block_dir: Some(cfg.block_dir.clone()),
+            ..Default::default()
+        },
     );
     if let Ok(chain) = Blockchain::load(&cfg.block_dir) {
         *node.chain_handle().lock().await = chain;

--- a/p2p/tests/consensus.rs
+++ b/p2p/tests/consensus.rs
@@ -1,5 +1,5 @@
 use coin::{Block, BlockHeader, Blockchain, coinbase_transaction, compute_merkle_root};
-use coin_p2p::{Node, NodeType};
+use coin_p2p::{Node, NodeConfig, NodeType};
 use coin_wallet::Wallet;
 use hex_literal::hex;
 use stake::Vote;
@@ -23,16 +23,10 @@ async fn finalize_block_on_votes() {
         vec!["0.0.0.0:0".parse().unwrap()],
         Duration::from_millis(50),
         NodeType::Verifier,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(dir.path().to_str().unwrap().to_string()),
+        NodeConfig {
+            block_dir: Some(dir.path().to_str().unwrap().to_string()),
+            ..Default::default()
+        },
     );
     {
         let chain_handle = node.chain_handle();

--- a/p2p/tests/handshake.rs
+++ b/p2p/tests/handshake.rs
@@ -1,4 +1,4 @@
-use coin_p2p::{Node, NodeType, sign_handshake, verify_handshake};
+use coin_p2p::{Node, NodeConfig, NodeType, sign_handshake, verify_handshake};
 use coin_proto::Handshake;
 use rand::rngs::OsRng;
 use secp256k1::{PublicKey, Secp256k1, SecretKey};

--- a/p2p/tests/handshake.rs
+++ b/p2p/tests/handshake.rs
@@ -69,48 +69,33 @@ async fn node_rejects_mismatched_handshake() {
     let node_a = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],
         NodeType::Wallet,
-        None,
-        None,
-        None,
-        None,
-        Some("net1".into()),
-        Some(1),
-        None,
-        None,
-        None,
-        None,
+        NodeConfig {
+            network_id: Some("net1".into()),
+            protocol_version: Some(1),
+            ..Default::default()
+        },
     );
     let (addrs, _) = node_a.start().await.unwrap();
     let addr = addrs[0];
     let node_b = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],
         NodeType::Wallet,
-        None,
-        None,
-        None,
-        None,
-        Some("net2".into()),
-        Some(1),
-        None,
-        None,
-        None,
-        None,
+        NodeConfig {
+            network_id: Some("net2".into()),
+            protocol_version: Some(1),
+            ..Default::default()
+        },
     );
     assert!(node_b.connect(addr).await.is_err());
     assert!(node_b.peers().await.is_empty());
     let node_c = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],
         NodeType::Wallet,
-        None,
-        None,
-        None,
-        None,
-        Some("net1".into()),
-        Some(2),
-        None,
-        None,
-        None,
-        None,
+        NodeConfig {
+            network_id: Some("net1".into()),
+            protocol_version: Some(2),
+            ..Default::default()
+        },
     );
     assert!(node_c.connect(addr).await.is_err());
     assert!(node_c.peers().await.is_empty());

--- a/p2p/tests/network.rs
+++ b/p2p/tests/network.rs
@@ -1,6 +1,6 @@
 use coin::{Block, BlockHeader, coinbase_transaction, compute_merkle_root};
 use coin_p2p::{
-    Node, NodeType,
+    Node, NodeConfig, NodeType,
     rpc::{RpcMessage, RpcTransport},
     sign_handshake,
 };
@@ -58,16 +58,11 @@ async fn network_votes_finalize_block() {
             vec!["127.0.0.1:0".parse().unwrap()],
             Duration::from_millis(50),
             NodeType::Verifier,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(10),
-            Some(8),
-            None,
-            None,
+            NodeConfig {
+                max_msgs_per_sec: Some(10),
+                max_peers: Some(8),
+                ..Default::default()
+            },
         );
         let (addrs_a, _) = node_a.start().await.unwrap();
         sleep(Duration::from_millis(50)).await;
@@ -77,16 +72,11 @@ async fn network_votes_finalize_block() {
             vec!["127.0.0.1:0".parse().unwrap()],
             Duration::from_millis(50),
             NodeType::Verifier,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(10),
-            Some(8),
-            None,
-            None,
+            NodeConfig {
+                max_msgs_per_sec: Some(10),
+                max_peers: Some(8),
+                ..Default::default()
+            },
         );
         let (_addrs_b, _) = node_b.start().await.unwrap();
         sleep(Duration::from_millis(50)).await;
@@ -96,16 +86,11 @@ async fn network_votes_finalize_block() {
             vec!["127.0.0.1:0".parse().unwrap()],
             Duration::from_millis(50),
             NodeType::Verifier,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(10),
-            Some(8),
-            None,
-            None,
+            NodeConfig {
+                max_msgs_per_sec: Some(10),
+                max_peers: Some(8),
+                ..Default::default()
+            },
         );
         let (_addrs_c, _) = node_c.start().await.unwrap();
         sleep(Duration::from_millis(50)).await;
@@ -192,16 +177,11 @@ async fn peer_limit_and_rate_limit() {
     let node = Node::new(
         vec!["127.0.0.1:0".parse().unwrap()],
         NodeType::Verifier,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(5),
-        Some(2),
-        None,
-        None,
+        NodeConfig {
+            max_msgs_per_sec: Some(5),
+            max_peers: Some(2),
+            ..Default::default()
+        },
     );
     let (addrs, _) = node.start().await.unwrap();
     sleep(Duration::from_millis(50)).await;

--- a/p2p/tests/persistence.rs
+++ b/p2p/tests/persistence.rs
@@ -1,5 +1,5 @@
 use coin::Blockchain;
-use coin_p2p::{Node, NodeType};
+use coin_p2p::{Node, NodeConfig, NodeType};
 use miner::mine_block;
 use tempfile::tempdir;
 

--- a/p2p/tests/persistence.rs
+++ b/p2p/tests/persistence.rs
@@ -12,16 +12,10 @@ async fn reloads_block_after_restart() {
     let node1 = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],
         NodeType::Wallet,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(dir.path().to_str().unwrap().to_string()),
+        NodeConfig {
+            block_dir: Some(dir.path().to_str().unwrap().to_string()),
+            ..Default::default()
+        },
     );
     let _ = node1.start().await.unwrap();
 
@@ -37,16 +31,10 @@ async fn reloads_block_after_restart() {
     let node2 = Node::new(
         vec!["0.0.0.0:0".parse().unwrap()],
         NodeType::Wallet,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        None,
-        Some(dir.path().to_str().unwrap().to_string()),
+        NodeConfig {
+            block_dir: Some(dir.path().to_str().unwrap().to_string()),
+            ..Default::default()
+        },
     );
     if let Ok(chain) = Blockchain::load(dir.path()) {
         *node2.chain_handle().lock().await = chain;


### PR DESCRIPTION
## Summary
- add `NodeConfig` struct to consolidate node options
- update `Node::new` and `Node::with_interval` to accept `NodeConfig`
- adjust examples and tests to build with the new struct

## Testing
- `cargo fmt --all`
- `cargo test` *(fails: couldn't complete due to environment limits)*
- `cargo tarpaulin --workspace --timeout 60 --fail-under 90` *(fails: tarpaulin missing)*

------
https://chatgpt.com/codex/tasks/task_e_6868aa76bdec832e886a749cd98ed654